### PR TITLE
Fix modal not showing when adding new record

### DIFF
--- a/main_gui.py
+++ b/main_gui.py
@@ -487,6 +487,7 @@ class AtaApp:
         self.current_edit_ata_id = None
         self._clear_modal_fields()
         self.modal.content.content.controls[0].content.controls[0].value = "Criar Nova Ata"
+        self.page.dialog = self.modal  # garante que o diálogo correto esteja configurado
         self.modal.open = True
         self.page.update()
         


### PR DESCRIPTION
## Summary
- ensure the page dialog is set before opening the modal

## Testing
- `python3 -m py_compile main_gui.py database.py`

------
https://chatgpt.com/codex/tasks/task_e_68791d7e0c308322af9d2ec050c5a4c1