### PR TITLE
Fix package imports for CLI execution

### DIFF
--- a/src/forms/ata_form.py
+++ b/src/forms/ata_form.py
@@ -1,8 +1,12 @@
 import flet as ft
 from datetime import date, datetime
 from typing import List, Dict, Any, Optional, Callable
-from ..models.ata import Ata, Item
-from ..utils.validators import Validators, Formatters, MaskUtils
+try:
+    from ..models.ata import Ata, Item
+    from ..utils.validators import Validators, Formatters, MaskUtils
+except ImportError:  # Execução direta sem pacote
+    from models.ata import Ata, Item
+    from utils.validators import Validators, Formatters, MaskUtils
 
 class AtaForm:
     """Formulário para criação e edição de atas"""


### PR DESCRIPTION
## Summary
- support running AtaForm when modules are imported without package context

## Testing
- `make build-up` *(fails to finish due to interactive UI)*
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687e8b42c75083228a456d85660e8d35