### PR TITLE
Fix missing method by moving entrypoint

### DIFF
--- a/src/main_gui.py
+++ b/src/main_gui.py
@@ -428,14 +428,6 @@ Itens:
         self.page.dialog.open = False
         self.page.update()
 
-def main(page: ft.Page):
-    app = AtaApp(page)
-
-if __name__ == "__main__":
-    ft.app(target=main)
-
-
-    
     def salvar_nova_ata(self, ata_data):
         """Salva uma nova ata"""
         try:
@@ -574,4 +566,12 @@ O sistema está monitorando automaticamente as atas e enviará alertas conforme 
         """Destrutor - para o agendador ao fechar a aplicação"""
         if hasattr(self, 'scheduler'):
             self.scheduler.stop()
+
+
+def main(page: ft.Page):
+    app = AtaApp(page)
+
+
+if __name__ == "__main__":
+    ft.app(target=main)
 


### PR DESCRIPTION
## Summary
- move `main` entrypoint outside of `AtaApp` class to avoid premature app start

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e8eb2c5f88322a2df58f99e83d440