### PR TITLE
Improve layout of filter/search row

### DIFF
--- a/src/main_gui.py
+++ b/src/main_gui.py
@@ -61,6 +61,20 @@ class AtaApp:
 
         search_container, self.search_field = build_search(self.buscar_atas)
 
+        # Ajusta margens para uso em linha
+        filtros.margin = ft.margin.only(bottom=0)
+        search_container.margin = ft.margin.only(bottom=0)
+
+        filtros_search_row = ft.Container(
+            content=ft.Row(
+                [filtros, search_container],
+                spacing=16,
+                alignment=ft.MainAxisAlignment.SPACE_BETWEEN,
+            ),
+            margin=ft.margin.only(bottom=16),
+            expand=True,
+        )
+
         self.data_table = build_data_table(
             self.get_atas_filtradas(),
             self.visualizar_ata,
@@ -82,7 +96,7 @@ class AtaApp:
         atas_tab = ft.Tab(
             text="Atas",
             content=ft.Column(
-                [filtros, search_container, self.data_table],
+                [filtros_search_row, self.data_table],
                 spacing=0,
                 expand=True,
             ),

--- a/src/ui/main_view.py
+++ b/src/ui/main_view.py
@@ -58,14 +58,18 @@ def build_filters(filtro_atual: str, filtro_cb: Callable[[str], None]) -> ft.Con
         )
 
     return ft.Container(
-        content=ft.Row([
-            button("✅ Vigentes", "vigente", ft.colors.GREEN),
-            button("⚠️ A Vencer", "a_vencer", ft.colors.ORANGE),
-            button("❌ Vencidas", "vencida", ft.colors.RED),
-            button("📋 Todas", "todos", ft.colors.BLUE),
-        ], spacing=10),
+        content=ft.Row(
+            [
+                button("✅ Vigentes", "vigente", ft.colors.GREEN),
+                button("⚠️ A Vencer", "a_vencer", ft.colors.ORANGE),
+                button("❌ Vencidas", "vencida", ft.colors.RED),
+                button("📋 Todas", "todos", ft.colors.BLUE),
+            ],
+            spacing=10,
+        ),
         padding=ft.padding.all(16),
         margin=ft.margin.only(bottom=16),
+        expand=True,
     )
 
 
@@ -74,10 +78,15 @@ def build_search(on_change: Callable) -> tuple[ft.Container, ft.TextField]:
         label="Buscar atas...",
         prefix_icon=ft.icons.SEARCH,
         on_change=on_change,
-        width=400,
+        expand=True,
     )
     return (
-        ft.Container(content=search_field, padding=ft.padding.all(16), margin=ft.margin.only(bottom=16)),
+        ft.Container(
+            content=search_field,
+            padding=ft.padding.all(16),
+            margin=ft.margin.only(bottom=16),
+            expand=True,
+        ),
         search_field,
     )
 


### PR DESCRIPTION
## Summary
- expand filter and search containers so controls use full width
- place filters and search field in a single row for a cleaner layout

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687e9beaaa408322af2814badd3c2f7a