### PR TITLE
Fix search text persistence

### DIFF
--- a/src/main_gui.py
+++ b/src/main_gui.py
@@ -59,7 +59,9 @@ class AtaApp:
 
         filtros = build_filters(self.filtro_atual, self.filtrar_atas)
 
-        search_container, self.search_field = build_search(self.buscar_atas)
+        search_container, self.search_field = build_search(
+            self.buscar_atas, self.texto_busca
+        )
 
         # Ajusta margens para uso em linha
         filtros.margin = ft.margin.only(bottom=0)

--- a/src/ui/main_view.py
+++ b/src/ui/main_view.py
@@ -73,11 +73,13 @@ def build_filters(filtro_atual: str, filtro_cb: Callable[[str], None]) -> ft.Con
     )
 
 
-def build_search(on_change: Callable) -> tuple[ft.Container, ft.TextField]:
+def build_search(on_change: Callable, value: str = "") -> tuple[ft.Container, ft.TextField]:
+    """Return a search container and field pre-populated with ``value``."""
     search_field = ft.TextField(
         label="Buscar atas...",
         prefix_icon=ft.icons.SEARCH,
         on_change=on_change,
+        value=value,
         expand=True,
     )
     return (


### PR DESCRIPTION
## Summary
- keep typed text in search field when refreshing UI
- pass stored search text back to search widget

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e9d67c11c83229ee176aab2d45ea1