### PR TITLE
Refactor UI layout with shared theme

### DIFF
--- a/src/dashboard_app.py
+++ b/src/dashboard_app.py
@@ -1,0 +1,273 @@
+import datetime
+import flet as ft
+
+try:
+    from services.ata_service import AtaService
+except ImportError:  # pragma: no cover - package relative import
+    from ..services.ata_service import AtaService
+
+try:
+    from ui.theme import Theme
+except ImportError:  # pragma: no cover - package relative import
+    from .ui.theme import Theme
+
+
+def calcular_status(vigencia: datetime.date) -> str:
+    hoje = datetime.date.today()
+    if vigencia < hoje:
+        return "Vencida"
+    dias = (vigencia - hoje).days
+    return "A vencer" if dias < 90 else "Vigente"
+
+
+def badge_status(status: str) -> ft.Container:
+    cor = {
+        "Vigente": Theme.BLUE,
+        "A vencer": Theme.YELLOW,
+        "Vencida": Theme.ORANGE,
+    }[status]
+    return ft.Container(
+        content=ft.Text(status, size=12, weight="bold", color=Theme.LIGHT),
+        bgcolor=cor,
+        border_radius=20,
+        padding=ft.Padding(8, 4, 8, 4),
+    )
+
+
+def side_menu(selected: str, page: ft.Page):
+    itens = [
+        ("Dashboard", ft.icons.DASHBOARD_OUTLINED),
+        ("Atas", ft.icons.LIBRARY_BOOKS_OUTLINED),
+        ("Configurações", ft.icons.SETTINGS_OUTLINED),
+    ]
+    rows = []
+    for rotulo, icone in itens:
+        ativo = rotulo == selected
+        rows.append(
+            ft.Container(
+                bgcolor=Theme.GREY if ativo else Theme.LIGHT,
+                border_radius=ft.border_radius.only(top_left=48, bottom_left=48),
+                padding=4,
+                content=ft.Row(
+                    controls=[
+                        ft.Icon(name=icone, color=Theme.BLUE if ativo else Theme.DARK),
+                        ft.Text(rotulo, visible=not page.drawer_open),
+                    ],
+                    vertical_alignment="center",
+                ),
+                on_click=lambda e, r=rotulo: print(f"trocar para {r}"),
+            )
+        )
+    return rows
+
+
+def main(page: ft.Page):
+    page.title = "ARP Dashboard"
+    page.fonts = {
+        "Poppins": "https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap",
+        "Lato": "https://fonts.googleapis.com/css2?family=Lato:wght@400;700&display=swap",
+    }
+    page.bgcolor = Theme.GREY
+    page.vertical_alignment = "start"
+
+    ata_service = AtaService()
+    atas = ata_service.listar_todas()
+
+    drawer = ft.Container(
+        width=280,
+        bgcolor=Theme.LIGHT,
+        content=ft.Column(
+            controls=[
+                ft.Container(
+                    padding=ft.Padding(0, 24),
+                    height=56,
+                    content=ft.Row(
+                        [
+                            ft.Icon(ft.icons.DESCRIPTION_OUTLINED, color=Theme.BLUE),
+                            ft.Text(
+                                "ARP\u00a0Dashboard",
+                                size=20,
+                                weight="bold",
+                                color=Theme.BLUE,
+                                font_family=Theme.FONT_TITLE,
+                            ),
+                        ],
+                        vertical_alignment="center",
+                    ),
+                ),
+                ft.Divider(height=1),
+                *side_menu("Dashboard", page),
+                ft.Expander(visible=False),
+                ft.Container(
+                    padding=ft.Padding(12, 4),
+                    content=ft.Row(
+                        [ft.Icon(ft.icons.LOGOUT, color=Theme.RED), ft.Text("Sair", color=Theme.RED)],
+                        vertical_alignment="center",
+                    ),
+                ),
+            ],
+            spacing=10,
+            scroll="adaptive",
+        ),
+    )
+
+    navbar = ft.Container(
+        height=56,
+        bgcolor=Theme.LIGHT,
+        padding=ft.Padding(24, 0),
+        content=ft.Row(
+            controls=[
+                ft.IconButton(
+                    icon=ft.icons.MENU,
+                    on_click=lambda e: setattr(page, "drawer_open", not getattr(page, "drawer_open", False)),
+                ),
+                ft.TextField(
+                    hint_text="Buscar atas...",
+                    width=300,
+                    height=36,
+                    border_radius=36,
+                    bgcolor=Theme.GREY,
+                    content_padding=ft.Padding(16, 0, 0, 0),
+                ),
+                ft.Row(expand=True),
+                ft.Stack(
+                    controls=[
+                        ft.Icon(ft.icons.NOTIFICATIONS_OUTLINED, size=24),
+                        ft.CircleAvatar(
+                            radius=10,
+                            bgcolor=Theme.RED,
+                            content=ft.Text("3", size=10, weight="bold", color=Theme.LIGHT),
+                            top=-4,
+                            left=12,
+                        ),
+                    ]
+                ),
+                ft.CircleAvatar(bgcolor=Theme.BLUE, content=ft.Text("AA", color=Theme.LIGHT)),
+            ],
+            vertical_alignment="center",
+            spacing=24,
+        ),
+    )
+
+    vigentes = sum(1 for a in atas if calcular_status(a.data_vigencia) == "Vigente")
+    a_vencer = sum(1 for a in atas if calcular_status(a.data_vigencia) == "A vencer")
+    vencidas = sum(1 for a in atas if calcular_status(a.data_vigencia) == "Vencida")
+    total = vigentes + a_vencer + vencidas
+
+    chart = ft.PieChart(
+        sections=[
+            ft.PieChartSection(value=vigentes, title=f"{vigentes} Vigentes", color=Theme.BLUE),
+            ft.PieChartSection(value=a_vencer, title=f"{a_vencer} A vencer", color=Theme.YELLOW),
+            ft.PieChartSection(value=vencidas, title=f"{vencidas} Vencidas", color=Theme.ORANGE),
+        ],
+        sections_space=6,
+        center_space_radius=50,
+        height=240,
+        width=240,
+    )
+
+    linhas_tabela = []
+    for ata in atas:
+        status = calcular_status(ata.data_vigencia)
+        linhas_tabela.append(
+            ft.DataRow(
+                cells=[
+                    ft.DataCell(ft.Text(ata.numero_ata)),
+                    ft.DataCell(ft.Text(ata.data_vigencia.strftime("%d/%m/%Y"))),
+                    ft.DataCell(ft.Text(ata.objeto)),
+                    ft.DataCell(ft.Text(ata.fornecedor)),
+                    ft.DataCell(badge_status(status)),
+                    ft.DataCell(
+                        ft.Row(
+                            [
+                                ft.IconButton(icon=ft.icons.VISIBILITY_OUTLINED, tooltip="Ver"),
+                                ft.IconButton(icon=ft.icons.EDIT_OUTLINED, tooltip="Editar"),
+                            ],
+                            spacing=0,
+                        )
+                    ),
+                ]
+            )
+        )
+
+    tabela_atas = ft.DataTable(
+        columns=[
+            ft.DataColumn(ft.Text("Número")),
+            ft.DataColumn(ft.Text("Vigência")),
+            ft.DataColumn(ft.Text("Objeto")),
+            ft.DataColumn(ft.Text("Fornecedor")),
+            ft.DataColumn(ft.Text("Situação")),
+            ft.DataColumn(ft.Text("Ações")),
+        ],
+        rows=linhas_tabela,
+        heading_row_color=Theme.LIGHT,
+        data_row_min_height=56,
+        column_spacing=12,
+        divider_thickness=0.5,
+    )
+
+    alertas = []
+    for ata in atas:
+        status = calcular_status(ata.data_vigencia)
+        if status == "A vencer":
+            dias = (ata.data_vigencia - datetime.date.today()).days
+            alertas.append(
+                ft.ListTile(
+                    leading=ft.Icon(ft.icons.WARNING_AMBER_OUTLINED, color=Theme.YELLOW),
+                    title=ft.Text(f"Ata {ata.numero_ata} vence em {dias}\u00a0dias"),
+                    subtitle=ft.Text(ata.data_vigencia.strftime("%d/%m/%Y")),
+                    trailing=ft.IconButton(icon=ft.icons.EMAIL_OUTLINED, tooltip="Enviar alerta"),
+                    bgcolor=Theme.GREY,
+                    shape=ft.RoundedRectangleBorder(radius=10),
+                )
+            )
+    lista_alertas = ft.Column(alertas, scroll="auto")
+
+    main_content = ft.Container(
+        padding=ft.Padding(24, 24, 24, 24),
+        content=ft.Column(
+            controls=[
+                ft.Row(
+                    controls=[
+                        ft.Text("Dashboard", size=32, weight="bold", font_family=Theme.FONT_TITLE),
+                    ],
+                    alignment="spaceBetween",
+                ),
+                ft.Row(
+                    [
+                        ft.Container(chart, expand=True),
+                        ft.Container(
+                            content=ft.Column(
+                                controls=[ft.Text("Atas a Vencer", size=24, weight="600"), lista_alertas],
+                                spacing=16,
+                            ),
+                            width=300,
+                        ),
+                    ],
+                    spacing=24,
+                ),
+                ft.Divider(height=32, opacity=0),
+                tabela_atas,
+            ],
+            spacing=24,
+            expand=True,
+        ),
+    )
+
+    root = ft.Row(
+        expand=True,
+        controls=[
+            drawer,
+            ft.Column(
+                controls=[navbar, main_content],
+                expand=True,
+            ),
+        ],
+        spacing=0,
+    )
+
+    page.add(root)
+
+
+if __name__ == "__main__":
+    ft.app(target=main)

--- a/src/main_gui.py
+++ b/src/main_gui.py
@@ -11,6 +11,7 @@ from utils.email_service import EmailService
 from utils.validators import Formatters
 from utils.scheduler import TaskScheduler
 from forms.ata_form import AtaForm
+from ui.theme import Theme
 from ui.main_view import (
     build_header,
     build_filters,
@@ -44,6 +45,12 @@ class AtaApp:
         self.page.window_height = 800
         self.page.theme_mode = ft.ThemeMode.LIGHT
         self.page.padding = 16
+        self.page.bgcolor = Theme.GREY
+        self.page.fonts = {
+            Theme.FONT_TITLE: "https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap",
+            Theme.FONT_TEXT: "https://fonts.googleapis.com/css2?family=Lato:wght@400;700&display=swap",
+        }
+        self.page.drawer_open = True
     
     def build_ui(self):
         """Constrói a interface do usuário usando navegação lateral"""
@@ -61,8 +68,9 @@ class AtaApp:
         self.update_body()
 
         layout = ft.Row(
-            [self.navigation_menu, ft.VerticalDivider(width=1), self.body_container],
+            [self.navigation_menu, self.body_container],
             expand=True,
+            spacing=0,
         )
 
         self.page.add(layout)

--- a/src/ui/navigation_menu.py
+++ b/src/ui/navigation_menu.py
@@ -1,117 +1,54 @@
 import flet as ft
 
-class PopupColorItem(ft.PopupMenuItem):
-    def __init__(self, color: str, name: str):
-        super().__init__()
-        self.content = ft.Row(
-            controls=[ft.Icon(name=ft.icons.COLOR_LENS_OUTLINED, color=color), ft.Text(name)]
-        )
-        self.data = color
-        self.on_click = self.seed_color_changed
+try:
+    from ui.theme import Theme
+except ImportError:  # pragma: no cover - package relative import
+    from .theme import Theme
 
-    def seed_color_changed(self, e):
-        self.page.theme = self.page.dark_theme = ft.Theme(color_scheme_seed=self.data)
-        self.page.update()
 
-class NavigationDestination:
-    def __init__(self, name: str, label: str, icon: str, selected_icon: str, index: int):
-        self.name = name
-        self.label = label
-        self.icon = icon
-        self.selected_icon = selected_icon
-        self.index = index
+class MenuItem(ft.Container):
+    """Single entry in the sidebar."""
 
-class NavigationItem(ft.Container):
-    def __init__(self, destination: NavigationDestination, item_clicked):
-        super().__init__()
-        self.destination = destination
-        self.ink = True
-        self.padding = 10
-        self.border_radius = 5
-        self.content = ft.Row([ft.Icon(destination.icon), ft.Text(destination.label)])
-        self.on_click = item_clicked
-
-class NavigationColumn(ft.Column):
-    def __init__(self, app, destinations: list[NavigationDestination]):
-        super().__init__()
-        self.app = app
-        self.destinations = destinations
-        self.selected_index = app.current_tab
-        self.expand = 4
-        self.spacing = 0
-        self.scroll = ft.ScrollMode.ALWAYS
-        self.width = 200
-        self.controls = self.get_navigation_items()
-
-    def before_update(self):
-        super().before_update()
-        self.update_selected_item()
-
-    def get_navigation_items(self):
-        items = []
-        for d in self.destinations:
-            items.append(NavigationItem(d, item_clicked=self.item_clicked))
-        return items
-
-    def item_clicked(self, e):
-        self.selected_index = e.control.destination.index
-        self.update_selected_item()
-        self.app.navigate_to(self.selected_index)
-
-    def update_selected_item(self):
-        for item in self.controls:
-            item.bgcolor = None
-            item.content.controls[0].name = item.destination.icon
-        sel = self.controls[self.selected_index]
-        sel.bgcolor = ft.colors.SECONDARY_CONTAINER
-        sel.content.controls[0].name = sel.destination.selected_icon
-
-class LeftNavigationMenu(ft.Column):
-    def __init__(self, app):
-        super().__init__()
-        self.app = app
-        self.destinations = [
-            NavigationDestination("dashboard", "Dashboard", ft.icons.INSIGHTS_OUTLINED, ft.icons.INSIGHTS, 0),
-            NavigationDestination("atas", "Atas", ft.icons.LIST_OUTLINED, ft.icons.LIST, 1),
-            NavigationDestination("vencimentos", "Vencimentos", ft.icons.ALARM_OUTLINED, ft.icons.ALARM, 2),
-        ]
-        self.rail = NavigationColumn(app, self.destinations)
-        self.dark_light_text = ft.Text("Light theme")
-        self.dark_light_icon = ft.IconButton(icon=ft.icons.BRIGHTNESS_2_OUTLINED, tooltip="Toggle brightness", on_click=self.theme_changed)
-        self.controls = [
-            self.rail,
-            ft.Column(
-                expand=1,
+    def __init__(self, app, index: int, label: str, icon: str):
+        active = app.current_tab == index
+        super().__init__(
+            bgcolor=Theme.GREY if active else Theme.LIGHT,
+            border_radius=ft.border_radius.only(top_left=48, bottom_left=48),
+            padding=4,
+            content=ft.Row(
                 controls=[
-                    ft.Row([self.dark_light_icon, self.dark_light_text]),
-                    ft.Row([
-                        ft.PopupMenuButton(
-                            icon=ft.icons.COLOR_LENS_OUTLINED,
-                            items=[
-                                PopupColorItem(color="deeppurple", name="Deep purple"),
-                                PopupColorItem(color="indigo", name="Indigo"),
-                                PopupColorItem(color="blue", name="Blue"),
-                                PopupColorItem(color="teal", name="Teal"),
-                                PopupColorItem(color="green", name="Green"),
-                                PopupColorItem(color="yellow", name="Yellow"),
-                                PopupColorItem(color="orange", name="Orange"),
-                                PopupColorItem(color="deeporange", name="Deep orange"),
-                                PopupColorItem(color="pink", name="Pink"),
-                            ],
-                        ),
-                        ft.Text("Seed color"),
-                    ])
+                    ft.Icon(name=icon, color=Theme.BLUE if active else Theme.DARK),
+                    ft.Text(label, visible=not getattr(app.page, "drawer_open", False)),
                 ],
+                vertical_alignment="center",
             ),
-        ]
+            on_click=lambda e: app.navigate_to(index),
+        )
 
-    def theme_changed(self, e):
-        if self.page.theme_mode == ft.ThemeMode.LIGHT:
-            self.page.theme_mode = ft.ThemeMode.DARK
-            self.dark_light_text.value = "Dark theme"
-            self.dark_light_icon.icon = ft.icons.BRIGHTNESS_HIGH
-        else:
-            self.page.theme_mode = ft.ThemeMode.LIGHT
-            self.dark_light_text.value = "Light theme"
-            self.dark_light_icon.icon = ft.icons.BRIGHTNESS_2
-        self.page.update()
+
+class LeftNavigationMenu(ft.Container):
+    """Sidebar navigation similar to the provided dashboard example."""
+
+    def __init__(self, app):
+        super().__init__(width=280, bgcolor=Theme.LIGHT)
+        self.app = app
+        self.update_menu()
+
+    def update_menu(self):
+        items = [
+            ("Dashboard", ft.icons.DASHBOARD_OUTLINED),
+            ("Atas", ft.icons.LIBRARY_BOOKS_OUTLINED),
+            ("Vencimentos", ft.icons.ALARM_OUTLINED),
+        ]
+        menu_items = [MenuItem(self.app, i, label, icon) for i, (label, icon) in enumerate(items)]
+        menu_items.append(ft.Expander(visible=False))
+        menu_items.append(
+            ft.Container(
+                padding=ft.Padding(12, 4),
+                content=ft.Row(
+                    [ft.Icon(ft.icons.LOGOUT, color=Theme.RED), ft.Text("Sair", color=Theme.RED)],
+                    vertical_alignment="center",
+                ),
+            )
+        )
+        self.content = ft.Column(controls=menu_items, spacing=10, scroll="adaptive")

--- a/src/ui/theme.py
+++ b/src/ui/theme.py
@@ -1,0 +1,17 @@
+class Theme:
+    """Color palette and fonts used across the UI."""
+
+    LIGHT = "#F9F9F9"
+    BLUE = "#3C91E6"
+    LIGHT_BLUE = "#CFE8FF"
+    GREY = "#EEEEEE"
+    DARK_GREY = "#AAAAAA"
+    DARK = "#342E37"
+    RED = "#DB504A"
+    YELLOW = "#FFCE26"
+    LIGHT_YELLOW = "#FFF2C6"
+    ORANGE = "#FD7238"
+    LIGHT_ORANGE = "#FFE0D3"
+
+    FONT_TITLE = "Poppins"
+    FONT_TEXT = "Lato"


### PR DESCRIPTION
## Summary
- introduce reusable `Theme` class for colors and fonts
- simplify sidebar navigation styling to match dashboard mockup
- apply theme settings in main GUI

## Testing
- `python3 test_imports.py`

------
https://chatgpt.com/codex/tasks/task_e_687eac3693ec83229250c35630a739ea