### PR TITLE
Refactor atas view to planner board

### DIFF
--- a/src/main_gui.py
+++ b/src/main_gui.py
@@ -15,7 +15,7 @@ from ui.main_view import (
     build_header,
     build_filters,
     build_search,
-    build_grouped_data_tables,
+    build_planner_board,
     build_atas_vencimento,
     build_stats_panel as ui_build_stats_panel,
 )
@@ -101,13 +101,13 @@ class AtaApp:
             margin=ft.margin.only(bottom=16),
             expand=True,
         )
-        self.grouped_tables = build_grouped_data_tables(
+        self.atas_board = build_planner_board(
             self.get_atas_filtradas(),
             self.visualizar_ata,
             self.editar_ata,
             self.excluir_ata,
         )
-        return ft.Column([filtros_search_row, self.grouped_tables], spacing=0, expand=True)
+        return ft.Column([filtros_search_row, self.atas_board], spacing=0, expand=True)
 
     def build_vencimentos_view(self):
         self.atas_vencimento_container = build_atas_vencimento(
@@ -156,14 +156,14 @@ class AtaApp:
     def buscar_atas(self, e):
         """Busca atas por texto"""
         self.texto_busca = e.control.value.strip()
-        # Atualiza apenas a tabela mantendo o texto digitado
-        new_table = build_grouped_data_tables(
+        # Atualiza apenas o board mantendo o texto digitado
+        new_board = build_planner_board(
             self.get_atas_filtradas(),
             self.visualizar_ata,
             self.editar_ata,
             self.excluir_ata,
         )
-        self.grouped_tables.controls = new_table.controls
+        self.atas_board.controls = new_board.controls
         self.search_field.value = self.texto_busca
         self.page.update()
     

--- a/src/ui/main_view.py
+++ b/src/ui/main_view.py
@@ -180,6 +180,81 @@ def build_grouped_data_tables(
     return ft.Column(cards, spacing=16)
 
 
+def build_planner_board(
+    atas: List[Ata],
+    visualizar_cb: Callable[[Ata], None],
+    editar_cb: Callable[[Ata], None],
+    excluir_cb: Callable[[Ata], None],
+) -> ft.Row:
+    """Return a planner-style board grouping atas by status."""
+    groups: dict[str, list[Ata]] = {"vigente": [], "a_vencer": [], "vencida": []}
+    for ata in atas:
+        groups[ata.status].append(ata)
+
+    labels = {
+        "vigente": "\u2705 Vigentes",
+        "a_vencer": "\u26A0\ufe0f A Vencer",
+        "vencida": "\u274c Vencidas",
+    }
+    colors = {
+        "vigente": ft.colors.GREEN_50,
+        "a_vencer": ft.colors.ORANGE_50,
+        "vencida": ft.colors.RED_50,
+    }
+
+    columns: list[ft.Control] = []
+    for status in ["vigente", "a_vencer", "vencida"]:
+        cards: list[ft.Control] = []
+        for ata in groups[status]:
+            data_formatada = Formatters.formatar_data_brasileira(ata.data_vigencia)
+            card = ft.Card(
+                content=ft.Container(
+                    content=ft.Column(
+                        [
+                            ft.Text(f"Ata {ata.numero_ata}", weight=ft.FontWeight.BOLD),
+                            ft.Text(f"Vencimento: {data_formatada}"),
+                            ft.Row(
+                                [
+                                    ft.IconButton(
+                                        icon=ft.icons.VISIBILITY,
+                                        tooltip="Visualizar",
+                                        on_click=lambda e, a=ata: visualizar_cb(a),
+                                    ),
+                                    ft.IconButton(
+                                        icon=ft.icons.EDIT,
+                                        tooltip="Editar",
+                                        on_click=lambda e, a=ata: editar_cb(a),
+                                    ),
+                                    ft.IconButton(
+                                        icon=ft.icons.DELETE,
+                                        tooltip="Excluir",
+                                        on_click=lambda e, a=ata: excluir_cb(a),
+                                    ),
+                                ],
+                                spacing=0,
+                            ),
+                        ],
+                        spacing=4,
+                    ),
+                    padding=ft.padding.all(8),
+                    bgcolor=colors[status],
+                    border_radius=8,
+                )
+            )
+            cards.append(card)
+
+        column = ft.Container(
+            content=ft.Column(
+                [ft.Text(labels[status], size=16, weight=ft.FontWeight.BOLD)] + cards,
+                spacing=8,
+            ),
+            width=260,
+        )
+        columns.append(column)
+
+    return ft.Row(columns, spacing=16, scroll=ft.ScrollMode.AUTO, expand=True)
+
+
 def build_atas_vencimento(
     atas_vencimento: List[Ata],
     visualizar_cb: Callable[[Ata], None],


### PR DESCRIPTION
## Summary
- implement `build_planner_board` to show atas as planner-style columns
- refactor main GUI to use the new board instead of grouped tables

## Testing
- `python test_imports.py`

------
https://chatgpt.com/codex/tasks/task_e_687eafd4b3f883229ca6af3d369bc058