### PR TITLE
Add design tokens and unify spacing

### DIFF
--- a/src/forms/ata_form.py
+++ b/src/forms/ata_form.py
@@ -1,6 +1,11 @@
 import flet as ft
 from datetime import date, datetime
 from typing import List, Dict, Any, Optional, Callable
+
+try:
+    from ..ui.tokens import SPACE_2, SPACE_3, SPACE_4, SPACE_5
+except Exception:  # pragma: no cover
+    from ui.tokens import SPACE_2, SPACE_3, SPACE_4, SPACE_5
 try:
     from ..models.ata import Ata, Item
     from ..utils.validators import Validators, Formatters, MaskUtils
@@ -77,9 +82,9 @@ class AtaForm:
         )
         
         # Containers para listas dinâmicas
-        self.telefones_container = ft.Column(spacing=8)
-        self.emails_container = ft.Column(spacing=8)
-        self.itens_container = ft.Column(spacing=8)
+        self.telefones_container = ft.Column(spacing=SPACE_2)
+        self.emails_container = ft.Column(spacing=SPACE_2)
+        self.itens_container = ft.Column(spacing=SPACE_2)
         
         # Preenche campos se estiver editando
         if self.is_edit_mode:
@@ -94,20 +99,20 @@ class AtaForm:
         dados_gerais = ft.Container(
             content=ft.Column([
                 ft.Text("📋 Dados Gerais", size=16, weight=ft.FontWeight.BOLD),
-                ft.Row([self.numero_ata_field, self.documento_sei_field], spacing=16),
-                ft.Row([self.data_vigencia_field], spacing=16),
+                ft.Row([self.numero_ata_field, self.documento_sei_field], spacing=SPACE_4),
+                ft.Row([self.data_vigencia_field], spacing=SPACE_4),
                 self.objeto_field,
                 self.fornecedor_field
-            ], spacing=16),
-            padding=ft.padding.all(16),
+            ], spacing=SPACE_4),
+            padding=ft.padding.all(SPACE_4),
             border=ft.border.all(1, ft.colors.OUTLINE),
             border_radius=8,
-            margin=ft.margin.only(bottom=16)
+            margin=ft.margin.only(bottom=SPACE_4)
         )
         
         telefones_section = ft.Container(
             content=ft.Column([
-                ft.Row([
+            ft.Row([
                     ft.Text("📞 Telefones", size=16, weight=ft.FontWeight.BOLD),
                     ft.IconButton(
                         icon=ft.icons.ADD,
@@ -116,11 +121,11 @@ class AtaForm:
                     )
                 ], alignment=ft.MainAxisAlignment.SPACE_BETWEEN),
                 self.telefones_container
-            ], spacing=8),
-            padding=ft.padding.all(16),
+            ], spacing=SPACE_2),
+            padding=ft.padding.all(SPACE_4),
             border=ft.border.all(1, ft.colors.OUTLINE),
             border_radius=8,
-            margin=ft.margin.only(bottom=16)
+            margin=ft.margin.only(bottom=SPACE_4)
         )
         
         emails_section = ft.Container(
@@ -134,11 +139,11 @@ class AtaForm:
                     )
                 ], alignment=ft.MainAxisAlignment.SPACE_BETWEEN),
                 self.emails_container
-            ], spacing=8),
-            padding=ft.padding.all(16),
+            ], spacing=SPACE_2),
+            padding=ft.padding.all(SPACE_4),
             border=ft.border.all(1, ft.colors.OUTLINE),
             border_radius=8,
-            margin=ft.margin.only(bottom=16)
+            margin=ft.margin.only(bottom=SPACE_4)
         )
         
         itens_section = ft.Container(
@@ -152,11 +157,11 @@ class AtaForm:
                     )
                 ], alignment=ft.MainAxisAlignment.SPACE_BETWEEN),
                 self.itens_container
-            ], spacing=8),
-            padding=ft.padding.all(16),
+            ], spacing=SPACE_2),
+            padding=ft.padding.all(SPACE_4),
             border=ft.border.all(1, ft.colors.OUTLINE),
             border_radius=8,
-            margin=ft.margin.only(bottom=16)
+            margin=ft.margin.only(bottom=SPACE_4)
         )
         
         # Botões
@@ -172,7 +177,7 @@ class AtaForm:
                 bgcolor=ft.colors.PRIMARY,
                 color=ft.colors.ON_PRIMARY
             )
-        ], alignment=ft.MainAxisAlignment.END, spacing=16)
+        ], alignment=ft.MainAxisAlignment.END, spacing=SPACE_4)
         
         # Layout principal
         content = ft.Column([
@@ -237,7 +242,7 @@ class AtaForm:
             tooltip="Remover telefone"
         )
 
-        row = ft.Row([telefone_field, remove_btn], spacing=8)
+        row = ft.Row([telefone_field, remove_btn], spacing=SPACE_2)
         remove_btn.on_click = lambda e, field=telefone_field, r=row: self.remove_telefone(field, r)
         self.telefones.append((telefone_field, row))
         self.telefones_container.controls.append(row)
@@ -264,7 +269,7 @@ class AtaForm:
             tooltip="Remover e-mail"
         )
 
-        row = ft.Row([email_field, remove_btn], spacing=8)
+        row = ft.Row([email_field, remove_btn], spacing=SPACE_2)
         remove_btn.on_click = lambda e, field=email_field, r=row: self.remove_email(field, r)
         self.emails.append((email_field, row))
         self.emails_container.controls.append(row)
@@ -311,7 +316,7 @@ class AtaForm:
             quantidade_field,
             valor_field,
             remove_btn
-        ], spacing=8)
+        ], spacing=SPACE_2)
         
         self.itens.append((descricao_field, quantidade_field, valor_field, row))
         self.itens_container.controls.append(row)

--- a/src/main_gui.py
+++ b/src/main_gui.py
@@ -20,6 +20,7 @@ from ui.main_view import (
 )
 from ui.navigation_menu import LeftNavigationMenu
 from ui import build_ata_detail_view
+from ui.tokens import SPACE_4
 
 class AtaApp:
     def __init__(self, page: ft.Page):
@@ -43,7 +44,7 @@ class AtaApp:
         self.page.window_width = 1200
         self.page.window_height = 800
         self.page.theme_mode = ft.ThemeMode.LIGHT
-        self.page.padding = 16
+        self.page.padding = SPACE_4
         self.page.bgcolor = "#F3F4F6"
         self.page.fonts = {"Inter": "https://fonts.gstatic.com/s/inter/v7/Inter-Regular.ttf"}
         self.page.theme = ft.Theme(font_family="Inter")

--- a/src/ui/ata_detail_view.py
+++ b/src/ui/ata_detail_view.py
@@ -3,6 +3,17 @@ from datetime import timedelta
 from typing import Callable
 
 try:
+    from .tokens import (
+        SPACE_1,
+        SPACE_2,
+        SPACE_3,
+        SPACE_4,
+        SPACE_5,
+    )
+except Exception:  # pragma: no cover
+    from tokens import SPACE_1, SPACE_2, SPACE_3, SPACE_4, SPACE_5
+
+try:
     from ..models.ata import Ata
     from ..utils.validators import Formatters
 except ImportError:  # standalone execution
@@ -40,7 +51,7 @@ def build_ata_detail_view(
                 ],
             ),
             ft.Row(
-                spacing=12,
+                spacing=SPACE_3,
                 controls=[
                     ft.OutlinedButton(
                         text="Voltar",
@@ -51,9 +62,9 @@ def build_ata_detail_view(
                             color="#4B5563",
                             side=ft.BorderSide(1, "#D1D5DB"),
                         ),
-                    ),
-                    ft.ElevatedButton(
-                        text="Editar",
+                        ),
+                        ft.ElevatedButton(
+                            text="Editar",
                         icon=ft.icons.EDIT_OUTLINED,
                         on_click=on_edit,
                         bgcolor="#3B82F6",
@@ -61,7 +72,7 @@ def build_ata_detail_view(
                         style=ft.ButtonStyle(
                             shape=ft.RoundedRectangleBorder(radius=8)
                         ),
-                    ),
+                        ),
                 ],
             ),
         ],
@@ -123,7 +134,7 @@ def build_ata_detail_view(
                                 ft.icons.DESCRIPTION_OUTLINED, color="#4F46E5"
                             ),
                             bgcolor="#E0E7FF",
-                            padding=8,
+                            padding=SPACE_2,
                             border_radius=8,
                         ),
                         ft.Text(
@@ -133,7 +144,7 @@ def build_ata_detail_view(
                             color="#1F2937",
                         ),
                     ],
-                    spacing=12,
+                    spacing=SPACE_3,
                     vertical_alignment=ft.CrossAxisAlignment.CENTER,
                 ),
                 ft.Column(
@@ -141,14 +152,14 @@ def build_ata_detail_view(
                         info_row("Documento SEI:", ata.documento_sei),
                         info_row("Objeto:", ata.objeto),
                     ],
-                    spacing=16,
+                    spacing=SPACE_4,
                 ),
                 timeline,
             ],
-            spacing=24,
+            spacing=SPACE_5,
         ),
         bgcolor="#F8FAFC",
-        padding=24,
+        padding=SPACE_5,
         border_radius=12,
     )
 
@@ -184,7 +195,7 @@ def build_ata_detail_view(
         rows=item_rows,
         heading_row_height=32,
         data_row_min_height=32,
-        column_spacing=12,
+        column_spacing=SPACE_3,
     )
 
     resumo_financeiro = ft.Container(
@@ -199,7 +210,7 @@ def build_ata_detail_view(
             ],
         ),
         bgcolor="#EEF2FF",
-        padding=16,
+        padding=SPACE_4,
         border_radius=8,
     )
 
@@ -213,7 +224,7 @@ def build_ata_detail_view(
                                 ft.icons.LIST_ALT_OUTLINED, color="#4F46E5"
                             ),
                             bgcolor="#E0E7FF",
-                            padding=8,
+                            padding=SPACE_2,
                             border_radius=8,
                         ),
                         ft.Text(
@@ -223,16 +234,16 @@ def build_ata_detail_view(
                             color="#1F2937",
                         ),
                     ],
-                    spacing=12,
+                    spacing=SPACE_3,
                     vertical_alignment=ft.CrossAxisAlignment.CENTER,
                 ),
                 itens_table,
                 resumo_financeiro,
             ],
-            spacing=24,
+            spacing=SPACE_5,
         ),
         bgcolor="#F8FAFC",
-        padding=24,
+        padding=SPACE_5,
         border_radius=12,
     )
 
@@ -246,7 +257,7 @@ def build_ata_detail_view(
                                 ft.icons.BUSINESS_OUTLINED, color="#EA580C"
                             ),
                             bgcolor="#FFEDD5",
-                            padding=8,
+                            padding=SPACE_2,
                             border_radius=8,
                         ),
                         ft.Text(
@@ -256,15 +267,15 @@ def build_ata_detail_view(
                             color="#1F2937",
                         ),
                     ],
-                    spacing=12,
+                    spacing=SPACE_3,
                     vertical_alignment=ft.CrossAxisAlignment.CENTER,
                 ),
                 ft.Text(ata.fornecedor, size=18),
             ],
-            spacing=16,
+            spacing=SPACE_4,
         ),
         bgcolor="#F8FAFC",
-        padding=24,
+        padding=SPACE_5,
         border_radius=12,
     )
 
@@ -302,7 +313,7 @@ def build_ata_detail_view(
                                 ft.icons.HEADSET_MIC_OUTLINED, color="#0F766E"
                             ),
                             bgcolor="#CCFBF1",
-                            padding=8,
+                            padding=SPACE_2,
                             border_radius=8,
                         ),
                         ft.Text(
@@ -312,24 +323,24 @@ def build_ata_detail_view(
                             color="#1F2937",
                         ),
                     ],
-                    spacing=12,
+                    spacing=SPACE_3,
                     vertical_alignment=ft.CrossAxisAlignment.CENTER,
                 ),
                 ft.Column(contatos_list, spacing=12),
             ],
-            spacing=16,
+            spacing=SPACE_4,
         ),
         bgcolor="#F8FAFC",
-        padding=24,
+        padding=SPACE_5,
         border_radius=12,
     )
 
     layout = ft.Row(
         [
-            ft.Column([dados_gerais, itens_section], spacing=24, expand=2),
-            ft.Column([fornecedor_section, contatos_section], spacing=24, expand=1),
+            ft.Column([dados_gerais, itens_section], spacing=SPACE_5, expand=2),
+            ft.Column([fornecedor_section, contatos_section], spacing=SPACE_5, expand=1),
         ],
-        spacing=32,
+        spacing=SPACE_6,
         vertical_alignment=ft.CrossAxisAlignment.START,
     )
 
@@ -337,7 +348,7 @@ def build_ata_detail_view(
         content=ft.Column([header, layout], spacing=32),
         width=1152,
         bgcolor="#FFFFFF",
-        padding=32,
+        padding=SPACE_6,
         border_radius=16,
         shadow=ft.BoxShadow(
             spread_radius=1,
@@ -349,7 +360,7 @@ def build_ata_detail_view(
 
     page_container = ft.Container(
         content=ft.Column([card], expand=True),
-        padding=32,
+        padding=SPACE_6,
         bgcolor="#F1F5F9",
         alignment=ft.alignment.top_center,
     )

--- a/src/ui/main_view.py
+++ b/src/ui/main_view.py
@@ -2,6 +2,27 @@ import flet as ft
 from typing import Callable, List
 
 try:
+    from .tokens import (
+        SPACE_1,
+        SPACE_2,
+        SPACE_3,
+        SPACE_4,
+        SPACE_5,
+        SPACE_6,
+        build_card,
+    )
+except Exception:  # pragma: no cover - fallback for standalone execution
+    from tokens import (
+        SPACE_1,
+        SPACE_2,
+        SPACE_3,
+        SPACE_4,
+        SPACE_5,
+        SPACE_6,
+        build_card,
+    )
+
+try:
     from ..models.ata import Ata
     from ..utils.validators import Formatters
     from ..utils.chart_utils import ChartUtils
@@ -42,6 +63,10 @@ def build_header(
                 on_click=nova_ata_cb,
                 bgcolor=ft.colors.BLUE,
                 color=ft.colors.WHITE,
+                style=ft.ButtonStyle(
+                    padding=ft.padding.symmetric(horizontal=SPACE_4, vertical=SPACE_2),
+                    shape=ft.RoundedRectangleBorder(radius=8),
+                ),
             ),
         ],
     )
@@ -54,6 +79,10 @@ def build_filters(filtro_atual: str, filtro_cb: Callable[[str], None]) -> ft.Con
             label,
             on_click=lambda e: filtro_cb(value),
             bgcolor=color if filtro_atual == value else ft.colors.SURFACE_VARIANT,
+            style=ft.ButtonStyle(
+                padding=ft.padding.symmetric(horizontal=SPACE_3, vertical=SPACE_2),
+                shape=ft.RoundedRectangleBorder(radius=8),
+            ),
         )
 
     return ft.Container(
@@ -64,10 +93,10 @@ def build_filters(filtro_atual: str, filtro_cb: Callable[[str], None]) -> ft.Con
                 button("❌ Vencidas", "vencida", ft.colors.RED),
                 button("📋 Todas", "todos", ft.colors.BLUE),
             ],
-            spacing=10,
+            spacing=SPACE_3,
         ),
-        padding=ft.padding.all(16),
-        margin=ft.margin.only(bottom=16),
+        padding=ft.padding.all(SPACE_4),
+        margin=ft.margin.only(bottom=SPACE_5),
         expand=True,
     )
 
@@ -80,12 +109,14 @@ def build_search(on_change: Callable, value: str = "") -> tuple[ft.Container, ft
         on_change=on_change,
         value=value,
         expand=True,
+        height=44,
+        content_padding=ft.padding.symmetric(horizontal=SPACE_4),
     )
     return (
         ft.Container(
             content=search_field,
-            padding=ft.padding.all(16),
-            margin=ft.margin.only(bottom=16),
+            padding=ft.padding.all(SPACE_4),
+            margin=ft.margin.only(bottom=SPACE_6),
             expand=True,
         ),
         search_field,
@@ -116,8 +147,8 @@ def build_data_table(
         for lbl in header_labels
     ]
     header_row = ft.Container(
-        content=ft.Row(header_cells, spacing=16),
-        padding=ft.padding.symmetric(vertical=12, horizontal=16),
+        content=ft.Row(header_cells, spacing=SPACE_4),
+        padding=ft.padding.symmetric(vertical=SPACE_3, horizontal=SPACE_4),
         bgcolor="#F9FAFB",
         border=ft.border.only(bottom=ft.BorderSide(1, "#E5E7EB")),
     )
@@ -155,7 +186,7 @@ def build_data_table(
         badge_text_color, badge_bg_color = badge_colors[ata.status]
         badge = ft.Container(
             ft.Text(ata.status.replace("_", " ").title(), size=12, weight=ft.FontWeight.W_500, color=badge_text_color),
-            padding=ft.padding.symmetric(vertical=2, horizontal=8),
+            padding=ft.padding.symmetric(vertical=SPACE_1, horizontal=SPACE_3),
             bgcolor=badge_bg_color,
             border_radius=6,
         )
@@ -190,7 +221,7 @@ def build_data_table(
                     icon_size=20,
                 ),
             ],
-            spacing=8,
+            spacing=SPACE_3,
             alignment=ft.MainAxisAlignment.CENTER,
         )
 
@@ -206,10 +237,10 @@ def build_data_table(
         row_container = ft.Container(
             content=ft.Row(
                 cells,
-                spacing=12,
+                spacing=SPACE_3,
                 vertical_alignment=ft.CrossAxisAlignment.CENTER,
             ),
-            padding=ft.padding.all(12),
+            padding=ft.padding.all(SPACE_3),
             border=ft.border.only(bottom=ft.BorderSide(1, "#E5E7EB")) if index < total - 1 else None,
         )
 
@@ -263,29 +294,17 @@ def build_grouped_data_tables(
     for status in ["vigente", "a_vencer", "vencida"]:
         atas_status = groups[status]
 
-        header = ft.Row(
-            [
-                ft.Container(
-                    content=ft.Icon(
-                        status_info[status]["icon"],
-                        color=status_info[status]["icon_color"],
-                        size=20,
-                    ),
-                    width=28,
-                    height=28,
-                    padding=ft.padding.all(4),
-                    bgcolor=status_info[status]["icon_bg"],
-                    border_radius=4,
-                ),
-                ft.Text(
-                    status_info[status]["title"],
-                    size=18,
-                    weight=ft.FontWeight.BOLD,
-                    color="#1F2937",
-                ),
-            ],
-            spacing=12,
-            vertical_alignment=ft.CrossAxisAlignment.CENTER,
+        icon = ft.Container(
+            content=ft.Icon(
+                status_info[status]["icon"],
+                color=status_info[status]["icon_color"],
+                size=20,
+            ),
+            width=28,
+            height=28,
+            padding=ft.padding.all(SPACE_1),
+            bgcolor=status_info[status]["icon_bg"],
+            border_radius=4,
         )
 
         table = build_data_table(
@@ -296,18 +315,7 @@ def build_grouped_data_tables(
             status,
         )
 
-        card = ft.Container(
-            content=ft.Column([header, table], spacing=16),
-            bgcolor="#FFFFFF",
-            padding=24,
-            shadow=ft.BoxShadow(
-                spread_radius=-1,
-                blur_radius=6,
-                color=ft.colors.with_opacity(0.1, ft.colors.BLACK),
-                offset=ft.Offset(0, 4),
-            ),
-            width=float("inf"),
-        )
+        card = build_card(status_info[status]["title"], icon, table)
         card.col = {"xs": 12, "lg": 4}
         card_controls.append(card)
 
@@ -315,8 +323,8 @@ def build_grouped_data_tables(
         card_controls,
         columns=12,
         alignment=ft.MainAxisAlignment.CENTER,
-        spacing=16,
-        run_spacing=16,
+        spacing=SPACE_6,
+        run_spacing=SPACE_6,
     )
 
     container = ft.Container(
@@ -354,8 +362,8 @@ def build_atas_vencimento(
                     ft.IconButton(icon=ft.icons.EMAIL, tooltip="Enviar Alerta", on_click=lambda e, ata=ata: alerta_cb(ata)),
                 ]),
             ], alignment=ft.MainAxisAlignment.SPACE_BETWEEN),
-            padding=ft.padding.all(12),
-            margin=ft.margin.only(bottom=8),
+            padding=ft.padding.all(SPACE_3),
+            margin=ft.margin.only(bottom=SPACE_2),
             border=ft.border.all(1, ft.colors.ORANGE),
             border_radius=8,
             bgcolor=ft.colors.ORANGE_50,
@@ -372,11 +380,11 @@ def build_atas_vencimento(
                 ),
                 ft.Column(items, spacing=0, horizontal_alignment=ft.CrossAxisAlignment.CENTER),
             ],
-            spacing=12,
+            spacing=SPACE_3,
             horizontal_alignment=ft.CrossAxisAlignment.CENTER,
         ),
         alignment=ft.alignment.center,
-        padding=ft.padding.all(16),
+        padding=ft.padding.all(SPACE_4),
         border=ft.border.all(1, ft.colors.OUTLINE),
         border_radius=8,
     )
@@ -411,21 +419,21 @@ def build_stats_panel(ata_service) -> ft.Container:
                         ),
                         value_chart,
                     ],
-                    spacing=16,
+                    spacing=SPACE_4,
                 ),
-                padding=ft.padding.all(16),
+                padding=ft.padding.all(SPACE_4),
                 border=ft.border.all(1, ft.colors.OUTLINE),
                 border_radius=8,
                 expand=True,
             ),
             ft.Container(content=monthly_chart, width=360),
         ],
-        spacing=16,
+        spacing=SPACE_4,
     )
 
     return ft.Container(
         content=ft.Column(
-            [urgency_indicator, summary_cards, charts_section], spacing=16
+            [urgency_indicator, summary_cards, charts_section], spacing=SPACE_4
         ),
-        margin=ft.margin.only(bottom=24),
+        margin=ft.margin.only(bottom=SPACE_5),
     )

--- a/src/ui/navigation_menu.py
+++ b/src/ui/navigation_menu.py
@@ -1,5 +1,10 @@
 import flet as ft
 
+try:
+    from .tokens import SPACE_2, SPACE_3, SPACE_5
+except Exception:  # pragma: no cover
+    from tokens import SPACE_2, SPACE_3, SPACE_5
+
 class PopupColorItem(ft.PopupMenuItem):
     def __init__(self, color: str, name: str):
         super().__init__()
@@ -26,9 +31,12 @@ class NavigationItem(ft.Container):
         super().__init__()
         self.destination = destination
         self.ink = True
-        self.padding = 10
+        self.padding = SPACE_3
         self.border_radius = 5
-        self.content = ft.Row([ft.Icon(destination.icon), ft.Text(destination.label)])
+        self.content = ft.Row(
+            [ft.Icon(destination.icon), ft.Text(destination.label)],
+            spacing=SPACE_2,
+        )
         self.on_click = item_clicked
 
 class NavigationColumn(ft.Column):
@@ -78,12 +86,16 @@ class LeftNavigationMenu(ft.Column):
         self.rail = NavigationColumn(app, self.destinations)
         self.dark_light_text = ft.Text("Light theme")
         self.dark_light_icon = ft.IconButton(icon=ft.icons.BRIGHTNESS_2_OUTLINED, tooltip="Toggle brightness", on_click=self.theme_changed)
+        self.padding = SPACE_5
+        self.spacing = SPACE_3
         self.controls = [
             self.rail,
             ft.Column(
                 expand=1,
+                spacing=SPACE_3,
+                alignment=ft.MainAxisAlignment.END,
                 controls=[
-                    ft.Row([self.dark_light_icon, self.dark_light_text]),
+                    ft.Row([self.dark_light_icon, self.dark_light_text], spacing=SPACE_2),
                     ft.Row([
                         ft.PopupMenuButton(
                             icon=ft.icons.COLOR_LENS_OUTLINED,
@@ -100,8 +112,9 @@ class LeftNavigationMenu(ft.Column):
                             ],
                         ),
                         ft.Text("Seed color"),
-                    ])
+                    ], spacing=SPACE_2)
                 ],
+                padding=ft.padding.only(top=SPACE_5),
             ),
         ]
 

--- a/src/ui/tokens.py
+++ b/src/ui/tokens.py
@@ -1,0 +1,34 @@
+SPACE_1 = 4
+SPACE_2 = 8
+SPACE_3 = 12
+SPACE_4 = 16
+SPACE_5 = 24
+SPACE_6 = 32
+
+import flet as ft
+
+PRIMARY = ft.colors.BLUE
+DANGER = ft.colors.RED
+SUCCESS = ft.colors.GREEN
+WARNING = ft.colors.ORANGE
+GREY_LIGHT = ft.colors.GREY_300
+
+def build_card(title: str, icon: ft.Control, content: ft.Control) -> ft.Control:
+    header = ft.Row(
+        [icon, ft.Text(title, size=16, weight=ft.FontWeight.W_600)],
+        spacing=SPACE_2,
+        vertical_alignment=ft.CrossAxisAlignment.CENTER,
+    )
+    return ft.Container(
+        content=ft.Column([header, content], spacing=SPACE_4),
+        padding=SPACE_5,
+        border=ft.border.all(1, GREY_LIGHT),
+        border_radius=12,
+        bgcolor=ft.colors.WHITE,
+        shadow=ft.BoxShadow(
+            spread_radius=0,
+            blur_radius=6,
+            color=ft.colors.with_opacity(0.1, ft.colors.BLACK),
+            offset=ft.Offset(0, 2),
+        ),
+    )


### PR DESCRIPTION
## Summary
- introduce `ui/tokens.py` with spacing constants and `build_card`
- refactor UI modules to reuse spacing tokens
- update navigation menu and pages to follow consistent padding
- adjust forms and detail views with the new design helpers

## Testing
- `make install`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6887ccb6640083229b48ff9ec5aef4ef