### PR TITLE
Fix missing spacing constant import

### DIFF
--- a/src/ui/ata_detail_view.py
+++ b/src/ui/ata_detail_view.py
@@ -9,9 +9,10 @@ try:
         SPACE_3,
         SPACE_4,
         SPACE_5,
+        SPACE_6,
     )
 except Exception:  # pragma: no cover
-    from tokens import SPACE_1, SPACE_2, SPACE_3, SPACE_4, SPACE_5
+    from tokens import SPACE_1, SPACE_2, SPACE_3, SPACE_4, SPACE_5, SPACE_6
 
 try:
     from ..models.ata import Ata


### PR DESCRIPTION
## Summary
- import `SPACE_6` in detail view module so viewing an ata does not raise NameError

## Testing
- `python3 test_imports.py`

------
https://chatgpt.com/codex/tasks/task_e_6887d20a9aa08322887fd77f3542032c