### PR TITLE
Fix column margin causing Flet error

### DIFF
--- a/src/forms/ata_form.py
+++ b/src/forms/ata_form.py
@@ -299,17 +299,19 @@ class AtaForm:
         card = ft.Container(
             content=ft.Column(
                 [
-                    ft.Column(
-                        [
-                            ft.Text(
-                                titulo,
-                                size=30,
-                                weight=ft.FontWeight.BOLD,
-                                color="#111827",
-                            ),
-                            ft.Divider(height=1, color="#E5E7EB"),
-                        ],
-                        spacing=0,
+                    ft.Container(
+                        content=ft.Column(
+                            [
+                                ft.Text(
+                                    titulo,
+                                    size=30,
+                                    weight=ft.FontWeight.BOLD,
+                                    color="#111827",
+                                ),
+                                ft.Divider(height=1, color="#E5E7EB"),
+                            ],
+                            spacing=0,
+                        ),
                         margin=ft.margin.only(bottom=32),
                     ),
                     dados_gerais,


### PR DESCRIPTION
## Summary
- remove invalid `margin` argument from `ft.Column`
- wrap column header in a `Container` so margin can be applied

## Testing
- `make install`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6887d9d9920c8322becf5cb9b029eb4c