### PR TITLE
Improve text responsiveness

### DIFF
--- a/src/forms/ata_form.py
+++ b/src/forms/ata_form.py
@@ -200,8 +200,16 @@ class AtaForm:
                             size=30,
                             weight=ft.FontWeight.BOLD,
                             color="#111827",
+                            max_lines=2,
+                            overflow=ft.TextOverflow.ELLIPSIS,
                         ),
-                        ft.Text(titulo, size=16, color="#6B7280"),
+                        ft.Text(
+                            titulo,
+                            size=16,
+                            color="#6B7280",
+                            max_lines=1,
+                            overflow=ft.TextOverflow.ELLIPSIS,
+                        ),
                     ],
                 )
             ],
@@ -461,11 +469,29 @@ class AtaForm:
         if erros:
             # Mostra erros
             erro_dialog = ft.AlertDialog(
-                title=ft.Text("Erros de Validação"),
-                content=ft.Column([
-                    ft.Text("Corrija os seguintes erros:"),
-                    *[ft.Text(f"• {erro}") for erro in erros]
-                ], tight=True),
+                title=ft.Text(
+                    "Erros de Validação",
+                    max_lines=1,
+                    overflow=ft.TextOverflow.ELLIPSIS,
+                ),
+                content=ft.Column(
+                    [
+                        ft.Text(
+                            "Corrija os seguintes erros:",
+                            max_lines=1,
+                            overflow=ft.TextOverflow.ELLIPSIS,
+                        ),
+                        *[
+                            ft.Text(
+                                f"• {erro}",
+                                max_lines=1,
+                                overflow=ft.TextOverflow.ELLIPSIS,
+                            )
+                            for erro in erros
+                        ],
+                    ],
+                    tight=True,
+                ),
                 actions=[ft.TextButton("OK", on_click=lambda e: self.close_error_dialog())]
             )
             self.page.dialog = erro_dialog

--- a/src/main_gui.py
+++ b/src/main_gui.py
@@ -21,7 +21,7 @@ from ui.main_view import (
 from ui.navigation_menu import LeftNavigationMenu
 from ui import build_ata_detail_view
 from ui.tokens import SPACE_4
-from ui.responsive import get_breakpoint
+from ui.responsive import get_breakpoint, padding_for, font_size_for
 
 class AtaApp:
     def __init__(self, page: ft.Page):
@@ -46,7 +46,8 @@ class AtaApp:
         self.page.window_width = 1200
         self.page.window_height = 800
         self.page.theme_mode = ft.ThemeMode.LIGHT
-        self.page.padding = SPACE_4
+        # responsive padding
+        self.page.padding = padding_for(self.page.width)
         self.page.bgcolor = "#F3F4F6"
         self.page.fonts = {"Inter": "https://fonts.gstatic.com/s/inter/v7/Inter-Regular.ttf"}
         self.page.theme = ft.Theme(font_family="Inter")
@@ -61,6 +62,7 @@ class AtaApp:
             relatorio_mensal_cb=lambda e: self.gerar_relatorio_manual("mensal"),
             testar_email_cb=self.testar_email,
             status_cb=self.mostrar_status_sistema,
+            width=self.page.width,
         )
 
         self.navigation_menu = LeftNavigationMenu(self)
@@ -147,6 +149,16 @@ class AtaApp:
         if new_bp != self.breakpoint:
             self.breakpoint = new_bp
             self.navigation_menu.update_layout(self.page.width)
+            self.page.padding = padding_for(self.page.width)  # responsive padding
+            self.page.appbar = build_header(
+                nova_ata_cb=self.nova_ata_click,
+                verificar_alertas_cb=self.verificar_alertas_manual,
+                relatorio_semanal_cb=lambda e: self.gerar_relatorio_manual("semanal"),
+                relatorio_mensal_cb=lambda e: self.gerar_relatorio_manual("mensal"),
+                testar_email_cb=self.testar_email,
+                status_cb=self.mostrar_status_sistema,
+                width=self.page.width,
+            )
             self.refresh_ui()
     
     def get_atas_filtradas(self):

--- a/src/ui/ata_detail_view.py
+++ b/src/ui/ata_detail_view.py
@@ -33,8 +33,22 @@ def build_ata_detail_view(
     def info_row(label: str, value: str) -> ft.Row:
         return ft.Row(
             [
-                ft.Text(label, weight=ft.FontWeight.W_500, color="#6B7280", width=128),
-                ft.Text(value, color="#1F2937", expand=True),
+                ft.Text(
+                    label,
+                    weight=ft.FontWeight.W_500,
+                    color="#6B7280",
+                    width=128,
+                    max_lines=1,
+                    overflow=ft.TextOverflow.ELLIPSIS,
+                ),
+                ft.Text(
+                    value,
+                    color="#1F2937",
+                    expand=True,
+                    max_lines=1,
+                    overflow=ft.TextOverflow.ELLIPSIS,
+                    no_wrap=True,
+                ),
             ]
         )
 
@@ -147,12 +161,35 @@ def build_ata_detail_view(
     item_rows = [
         ft.DataRow(
             cells=[
-                ft.DataCell(ft.Text(item.descricao)),
-                ft.DataCell(ft.Text(str(item.quantidade))),
-                ft.DataCell(ft.Text(Formatters.formatar_valor_monetario(item.valor))),
                 ft.DataCell(
                     ft.Text(
-                        Formatters.formatar_valor_monetario(item.valor_total)
+                        item.descricao,
+                        max_lines=1,
+                        overflow=ft.TextOverflow.ELLIPSIS,
+                    )
+                ),
+                ft.DataCell(
+                    ft.Text(
+                        str(item.quantidade),
+                        max_lines=1,
+                        overflow=ft.TextOverflow.ELLIPSIS,
+                        no_wrap=True,
+                    )
+                ),
+                ft.DataCell(
+                    ft.Text(
+                        Formatters.formatar_valor_monetario(item.valor),
+                        max_lines=1,
+                        overflow=ft.TextOverflow.ELLIPSIS,
+                        no_wrap=True,
+                    )
+                ),
+                ft.DataCell(
+                    ft.Text(
+                        Formatters.formatar_valor_monetario(item.valor_total),
+                        max_lines=1,
+                        overflow=ft.TextOverflow.ELLIPSIS,
+                        no_wrap=True,
                     )
                 ),
             ]
@@ -162,15 +199,40 @@ def build_ata_detail_view(
 
     itens_table = ft.DataTable(
         columns=[
-            ft.DataColumn(ft.Text("Descrição", weight=ft.FontWeight.W_600)),
             ft.DataColumn(
-                ft.Text("Qtd.", weight=ft.FontWeight.W_600), numeric=True
+                ft.Text(
+                    "Descrição",
+                    weight=ft.FontWeight.W_600,
+                    max_lines=1,
+                    overflow=ft.TextOverflow.ELLIPSIS,
+                )
             ),
             ft.DataColumn(
-                ft.Text("Valor Unit.", weight=ft.FontWeight.W_600), numeric=True
+                ft.Text(
+                    "Qtd.",
+                    weight=ft.FontWeight.W_600,
+                    max_lines=1,
+                    overflow=ft.TextOverflow.ELLIPSIS,
+                ),
+                numeric=True,
             ),
             ft.DataColumn(
-                ft.Text("Subtotal", weight=ft.FontWeight.W_600), numeric=True
+                ft.Text(
+                    "Valor Unit.",
+                    weight=ft.FontWeight.W_600,
+                    max_lines=1,
+                    overflow=ft.TextOverflow.ELLIPSIS,
+                ),
+                numeric=True,
+            ),
+            ft.DataColumn(
+                ft.Text(
+                    "Subtotal",
+                    weight=ft.FontWeight.W_600,
+                    max_lines=1,
+                    overflow=ft.TextOverflow.ELLIPSIS,
+                ),
+                numeric=True,
             ),
         ],
         rows=item_rows,

--- a/src/ui/main_view.py
+++ b/src/ui/main_view.py
@@ -1,5 +1,6 @@
 import flet as ft
 from typing import Callable, List
+from .responsive import font_size_for
 
 try:
     from .tokens import (
@@ -21,6 +22,7 @@ except Exception:  # pragma: no cover - fallback for standalone execution
         SPACE_6,
         build_card,
     )
+    from responsive import font_size_for
 
 try:
     from ..models.ata import Ata
@@ -39,12 +41,19 @@ def build_header(
     relatorio_mensal_cb: Callable,
     testar_email_cb: Callable,
     status_cb: Callable,
+    width: int,
 ) -> ft.AppBar:
     """Return AppBar with menu actions and new ata button."""
     return ft.AppBar(
         leading=ft.Icon(ft.icons.DESCRIPTION_OUTLINED),
         leading_width=40,
-        title=ft.Text("Ata de Registro de Preços"),
+        title=ft.Text(
+            "Ata de Registro de Preços",
+            size=font_size_for(width, 18),
+            max_lines=1,
+            overflow=ft.TextOverflow.ELLIPSIS,
+            no_wrap=True,
+        ),  # responsive font
         bgcolor=ft.colors.INVERSE_PRIMARY,
         actions=[
             ft.PopupMenuButton(
@@ -351,11 +360,24 @@ def build_atas_vencimento(
         item = ft.Container(
             content=ft.Row([
                 ft.Column([
-                    ft.Text(f"Ata: {ata.numero_ata}", weight=ft.FontWeight.BOLD),
-                    ft.Text(f"Vencimento: {data_formatada}"),
+                    ft.Text(
+                        f"Ata: {ata.numero_ata}",
+                        weight=ft.FontWeight.BOLD,
+                        max_lines=1,
+                        overflow=ft.TextOverflow.ELLIPSIS,
+                        no_wrap=True,
+                    ),
+                    ft.Text(
+                        f"Vencimento: {data_formatada}",
+                        max_lines=1,
+                        overflow=ft.TextOverflow.ELLIPSIS,
+                        no_wrap=True,
+                    ),
                     ft.Text(
                         f"Faltam {ata.dias_restantes} dias",
                         color=ft.colors.RED if ata.dias_restantes <= 30 else ft.colors.ORANGE,
+                        max_lines=1,
+                        overflow=ft.TextOverflow.ELLIPSIS,
                     ),
                 ], spacing=4),
                 ft.Row([
@@ -378,6 +400,8 @@ def build_atas_vencimento(
                     "🔔 Atas Próximas do Vencimento",
                     size=16,
                     weight=ft.FontWeight.BOLD,
+                    max_lines=1,
+                    overflow=ft.TextOverflow.ELLIPSIS,
                 ),
                 ft.Column(items, spacing=0, horizontal_alignment=ft.CrossAxisAlignment.CENTER),
             ],

--- a/src/ui/navigation_menu.py
+++ b/src/ui/navigation_menu.py
@@ -9,7 +9,15 @@ class PopupColorItem(ft.PopupMenuItem):
     def __init__(self, color: str, name: str):
         super().__init__()
         self.content = ft.Row(
-            controls=[ft.Icon(name=ft.icons.COLOR_LENS_OUTLINED, color=color), ft.Text(name)]
+            controls=[
+                ft.Icon(name=ft.icons.COLOR_LENS_OUTLINED, color=color),
+                ft.Text(
+                    name,
+                    max_lines=1,
+                    overflow=ft.TextOverflow.ELLIPSIS,
+                    no_wrap=True,
+                ),
+            ]
         )
         self.data = color
         self.on_click = self.seed_color_changed
@@ -34,7 +42,15 @@ class NavigationItem(ft.Container):
         self.padding = SPACE_3
         self.border_radius = 5
         self.content = ft.Row(
-            [ft.Icon(destination.icon), ft.Text(destination.label)],
+            [
+                ft.Icon(destination.icon),
+                ft.Text(
+                    destination.label,
+                    max_lines=1,
+                    overflow=ft.TextOverflow.ELLIPSIS,
+                    no_wrap=True,
+                ),
+            ],
             spacing=SPACE_2,
         )
         self.on_click = item_clicked
@@ -97,7 +113,12 @@ class LeftNavigationMenu(ft.Column):
             NavigationDestination("vencimentos", "Vencimentos", ft.icons.ALARM_OUTLINED, ft.icons.ALARM, 2),
         ]
         self.rail = NavigationColumn(app, self.destinations)
-        self.dark_light_text = ft.Text("Light theme")
+        self.dark_light_text = ft.Text(
+            "Light theme",
+            max_lines=1,
+            overflow=ft.TextOverflow.ELLIPSIS,
+            no_wrap=True,
+        )
         self.dark_light_icon = ft.IconButton(icon=ft.icons.BRIGHTNESS_2_OUTLINED, tooltip="Toggle brightness", on_click=self.theme_changed)
         self.padding = SPACE_5
         self.spacing = SPACE_3
@@ -126,7 +147,12 @@ class LeftNavigationMenu(ft.Column):
                                     PopupColorItem(color="pink", name="Pink"),
                                 ],
                             ),
-                            ft.Text("Seed color"),
+                            ft.Text(
+                                "Seed color",
+                                max_lines=1,
+                                overflow=ft.TextOverflow.ELLIPSIS,
+                                no_wrap=True,
+                            ),
                         ], spacing=SPACE_2)
                     ],
                 ),

--- a/src/ui/responsive.py
+++ b/src/ui/responsive.py
@@ -17,6 +17,16 @@ FONT_SCALE = {
     "lg": 1.1,
 }
 
+# helpers to expose intuitive API
+def font_size_for(width: int, base: int) -> int:
+    """Return scaled font size for given ``width``."""  # responsive font
+    return get_font_size(width, base)
+
+
+def padding_for(width: int) -> int:
+    """Return padding size for given ``width``."""  # responsive padding
+    return get_padding(width)
+
 def get_breakpoint(width: int) -> str:
     """Return breakpoint name based on ``width``."""
     if width < BREAKPOINT_SM:
@@ -41,3 +51,7 @@ def get_font_size(width: int, base: int) -> int:
 # - componentes expansíveis usando col/expand
 # - fontes e paddings dinâmicos via helpers
 # - overflow horizontal evitado
+# - max_lines/overflow nos textos críticos
+# - fontes/paddings por breakpoint
+# - sem overflow horizontal
+# - DataTable e badges tratados

--- a/src/ui/tokens.py
+++ b/src/ui/tokens.py
@@ -31,7 +31,14 @@ def build_section(
                 padding=SPACE_2,
                 border_radius=8,
             ),
-            ft.Text(title, size=20, weight=ft.FontWeight.BOLD, color="#1F2937"),
+            ft.Text(
+                title,
+                size=20,
+                weight=ft.FontWeight.BOLD,
+                color="#1F2937",
+                max_lines=1,
+                overflow=ft.TextOverflow.ELLIPSIS,
+            ),
         ],
         spacing=SPACE_3,
         vertical_alignment=ft.CrossAxisAlignment.CENTER,
@@ -46,7 +53,16 @@ def build_section(
 
 def build_card(title: str, icon: ft.Control, content: ft.Control) -> ft.Control:
     header = ft.Row(
-        [icon, ft.Text(title, size=16, weight=ft.FontWeight.W_600)],
+        [
+            icon,
+            ft.Text(
+                title,
+                size=16,
+                weight=ft.FontWeight.W_600,
+                max_lines=1,
+                overflow=ft.TextOverflow.ELLIPSIS,
+            ),
+        ],
         spacing=SPACE_2,
         vertical_alignment=ft.CrossAxisAlignment.CENTER,
     )

--- a/src/utils/chart_utils.py
+++ b/src/utils/chart_utils.py
@@ -18,7 +18,11 @@ class ChartUtils:
         
         if total == 0:
             return ft.Container(
-                content=ft.Text("Nenhuma ata cadastrada"),
+                content=ft.Text(
+                    "Nenhuma ata cadastrada",
+                    max_lines=1,
+                    overflow=ft.TextOverflow.ELLIPSIS,
+                ),
                 width=width,
                 height=height,
                 alignment=ft.alignment.center
@@ -64,7 +68,15 @@ class ChartUtils:
         total = sum(stats.values())
         
         if total == 0:
-            return ft.Column([ft.Text("Nenhuma ata cadastrada")])
+            return ft.Column(
+                [
+                    ft.Text(
+                        "Nenhuma ata cadastrada",
+                        max_lines=1,
+                        overflow=ft.TextOverflow.ELLIPSIS,
+                    )
+                ]
+            )
         
         # Ícones e cores para cada status
         status_info = {
@@ -166,7 +178,11 @@ class ChartUtils:
         
         if total_value == 0:
             return ft.Container(
-                content=ft.Text("Nenhum valor cadastrado"),
+                content=ft.Text(
+                    "Nenhum valor cadastrado",
+                    max_lines=1,
+                    overflow=ft.TextOverflow.ELLIPSIS,
+                ),
                 padding=ft.padding.all(16)
             )
         
@@ -194,14 +210,25 @@ class ChartUtils:
                 
                 bar = ft.Container(
                     content=ft.Row([
-                        ft.Text(labels[status], width=80),
+                        ft.Text(
+                            labels[status],
+                            width=80,
+                            max_lines=1,
+                            overflow=ft.TextOverflow.ELLIPSIS,
+                            no_wrap=True,
+                        ),
                         ft.Container(
                             width=bar_width,
                             height=20,
                             bgcolor=colors[status],
                             border_radius=2
                         ),
-                        ft.Text(f"{percentage:.1f}% ({value_formatted})", size=12)
+                        ft.Text(
+                            f"{percentage:.1f}% ({value_formatted})",
+                            size=12,
+                            max_lines=1,
+                            overflow=ft.TextOverflow.ELLIPSIS,
+                        )
                     ], spacing=8, alignment=ft.MainAxisAlignment.START),
                     margin=ft.margin.only(bottom=8)
                 )
@@ -224,10 +251,18 @@ class ChartUtils:
         """Cria indicador de urgência para atas próximas do vencimento"""
         if not atas_vencimento:
             return ft.Container(
-                content=ft.Row([
-                    ft.Icon(ft.icons.CHECK_CIRCLE, color=ft.colors.GREEN, size=24),
-                    ft.Text("Nenhuma ata próxima do vencimento", color=ft.colors.GREEN)
-                ], spacing=8),
+                content=ft.Row(
+                    [
+                        ft.Icon(ft.icons.CHECK_CIRCLE, color=ft.colors.GREEN, size=24),
+                        ft.Text(
+                            "Nenhuma ata próxima do vencimento",
+                            color=ft.colors.GREEN,
+                            max_lines=1,
+                            overflow=ft.TextOverflow.ELLIPSIS,
+                        ),
+                    ],
+                    spacing=8,
+                ),
                 padding=ft.padding.all(16),
                 border=ft.border.all(1, ft.colors.GREEN),
                 border_radius=8,


### PR DESCRIPTION
## Summary
- add responsive helpers and checklist
- update app bar to use responsive font
- adjust padding on resize
- apply ellipsis settings to long texts in navigation, forms, tables and cards
- update chart utilities with truncation for messages

## Testing
- `python3 test_imports.py`

------
https://chatgpt.com/codex/tasks/task_e_6887ef4a31b083228d14fc4f8542361d