### PR TITLE
refactor: padroniza estilo dos botões retangulares

### DIFF
--- a/src/forms/ata_form.py
+++ b/src/forms/ata_form.py
@@ -3,9 +3,25 @@ from datetime import date, datetime
 from typing import List, Dict, Any, Optional, Callable
 
 try:
-    from ..ui.tokens import SPACE_2, SPACE_3, SPACE_4, SPACE_5, build_section
+    from ..ui.tokens import (
+        SPACE_2,
+        SPACE_3,
+        SPACE_4,
+        SPACE_5,
+        build_section,
+        primary_button,
+        secondary_button,
+    )
 except Exception:  # pragma: no cover
-    from ui.tokens import SPACE_2, SPACE_3, SPACE_4, SPACE_5, build_section
+    from ui.tokens import (
+        SPACE_2,
+        SPACE_3,
+        SPACE_4,
+        SPACE_5,
+        build_section,
+        primary_button,
+        secondary_button,
+    )
 try:
     from ..models.ata import Ata, Item
     from ..utils.validators import Validators, Formatters, MaskUtils
@@ -176,19 +192,20 @@ class AtaForm:
         )
         
         # Botões
-        botoes = ft.Row([
-            ft.ElevatedButton(
-                "Cancelar",
-                on_click=lambda e: self.on_cancel(),
-                color=ft.colors.ON_SURFACE
-            ),
-            ft.ElevatedButton(
-                "Salvar",
-                on_click=self.save_ata,
-                bgcolor=ft.colors.PRIMARY,
-                color=ft.colors.ON_PRIMARY
-            )
-        ], alignment=ft.MainAxisAlignment.END, spacing=SPACE_4)
+        botoes = ft.Row(
+            [
+                secondary_button(
+                    "Cancelar",
+                    on_click=lambda e: self.on_cancel(),
+                ),
+                primary_button(
+                    "Salvar",
+                    on_click=self.save_ata,
+                ),
+            ],
+            alignment=ft.MainAxisAlignment.END,
+            spacing=SPACE_4,
+        )
         
         header = ft.Row(
             [

--- a/src/ui/ata_detail_view.py
+++ b/src/ui/ata_detail_view.py
@@ -11,9 +11,21 @@ try:
         SPACE_5,
         SPACE_6,
         build_section,
+        primary_button,
+        secondary_button,
     )
 except Exception:  # pragma: no cover
-    from tokens import SPACE_1, SPACE_2, SPACE_3, SPACE_4, SPACE_5, SPACE_6, build_section
+    from tokens import (
+        SPACE_1,
+        SPACE_2,
+        SPACE_3,
+        SPACE_4,
+        SPACE_5,
+        SPACE_6,
+        build_section,
+        primary_button,
+        secondary_button,
+    )
 
 try:
     from ..models.ata import Ata
@@ -55,26 +67,16 @@ def build_ata_detail_view(
             ft.Row(
                 spacing=SPACE_3,
                 controls=[
-                    ft.OutlinedButton(
-                        text="Voltar",
+                    secondary_button(
+                        "Voltar",
                         icon=ft.icons.ARROW_BACK_ROUNDED,
                         on_click=on_back,
-                        style=ft.ButtonStyle(
-                            shape=ft.RoundedRectangleBorder(radius=8),
-                            color="#4B5563",
-                            side=ft.BorderSide(1, "#D1D5DB"),
-                        ),
-                        ),
-                        ft.ElevatedButton(
-                            text="Editar",
+                    ),
+                    primary_button(
+                        "Editar",
                         icon=ft.icons.EDIT_OUTLINED,
                         on_click=on_edit,
-                        bgcolor="#3B82F6",
-                        color="#FFFFFF",
-                        style=ft.ButtonStyle(
-                            shape=ft.RoundedRectangleBorder(radius=8)
-                        ),
-                        ),
+                    ),
                 ],
             ),
         ],

--- a/src/ui/main_view.py
+++ b/src/ui/main_view.py
@@ -10,6 +10,7 @@ try:
         SPACE_5,
         SPACE_6,
         build_card,
+        primary_button,
     )
 except Exception:  # pragma: no cover - fallback for standalone execution
     from tokens import (
@@ -20,6 +21,7 @@ except Exception:  # pragma: no cover - fallback for standalone execution
         SPACE_5,
         SPACE_6,
         build_card,
+        primary_button,
     )
 
 try:
@@ -58,15 +60,10 @@ def build_header(
                     ft.PopupMenuItem(text="ℹ️ Status Sistema", on_click=status_cb),
                 ],
             ),
-            ft.ElevatedButton(
-                "➕ Nova Ata",
+            primary_button(
+                "Nova Ata",
+                icon=ft.icons.ADD,
                 on_click=nova_ata_cb,
-                bgcolor=ft.colors.BLUE,
-                color=ft.colors.WHITE,
-                style=ft.ButtonStyle(
-                    padding=ft.padding.symmetric(horizontal=SPACE_4, vertical=SPACE_2),
-                    shape=ft.RoundedRectangleBorder(radius=8),
-                ),
             ),
         ],
     )

--- a/src/ui/tokens.py
+++ b/src/ui/tokens.py
@@ -6,6 +6,7 @@ SPACE_5 = 24
 SPACE_6 = 32
 
 import flet as ft
+from typing import Callable, Optional
 
 PRIMARY = ft.colors.BLUE
 DANGER = ft.colors.RED
@@ -13,6 +14,44 @@ SUCCESS = ft.colors.GREEN
 WARNING = ft.colors.ORANGE
 GREY_LIGHT = ft.colors.GREY_300
 CARD_BG = "#F8FAFC"
+
+
+def primary_button(
+    text: str,
+    *,
+    icon: Optional[str] = None,
+    on_click: Optional[Callable[[ft.ControlEvent], None]] = None,
+) -> ft.ElevatedButton:
+    """Return a standard primary button used across the app."""
+
+    return ft.ElevatedButton(
+        text=text,
+        icon=icon,
+        on_click=on_click,
+        bgcolor="#3B82F6",
+        color="#FFFFFF",
+        style=ft.ButtonStyle(shape=ft.RoundedRectangleBorder(radius=8)),
+    )
+
+
+def secondary_button(
+    text: str,
+    *,
+    icon: Optional[str] = None,
+    on_click: Optional[Callable[[ft.ControlEvent], None]] = None,
+) -> ft.OutlinedButton:
+    """Return a standard secondary button used across the app."""
+
+    return ft.OutlinedButton(
+        text=text,
+        icon=icon,
+        on_click=on_click,
+        style=ft.ButtonStyle(
+            shape=ft.RoundedRectangleBorder(radius=8),
+            color="#4B5563",
+            side=ft.BorderSide(1, "#D1D5DB"),
+        ),
+    )
 
 def build_section(
     title: str,


### PR DESCRIPTION
## Summary
- cria helpers `primary_button` e `secondary_button` para unificar estilos
- aplica estilos padronizados nos botões de Visualizar Ata, formulário e AppBar

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6890ddda902c8322917d8fd6b5fd3498