### PR TITLE
fix: remove deprecated Size reference in filter buttons

### DIFF
--- a/src/ui/main_view.py
+++ b/src/ui/main_view.py
@@ -125,12 +125,12 @@ def build_filters(
         )
         return ft.ElevatedButton(
             content=content,
+            width=140,
             height=48,
             style=ft.ButtonStyle(
                 padding=ft.padding.symmetric(horizontal=16),
                 shape=ft.RoundedRectangleBorder(radius=8),
                 bgcolor=bg,
-                minimum_size=ft.Size(140, 48),
             ),
             on_click=lambda e: filtro_cb(value),
         )


### PR DESCRIPTION
## Summary
- remove usage of `ft.Size` and minimum_size in filter buttons
- set explicit width on elevated buttons for consistent layout

## Testing
- `python test_imports.py`


------
https://chatgpt.com/codex/tasks/task_e_6890e56fad7883228136bb2792f90efd