### PR TITLE
fix: remove ft.Size usage in filter buttons

### DIFF
--- a/src/ui/main_view.py
+++ b/src/ui/main_view.py
@@ -126,11 +126,11 @@ def build_filters(
         return ft.ElevatedButton(
             content=content,
             height=48,
+            width=140,
             style=ft.ButtonStyle(
                 padding=ft.padding.symmetric(horizontal=16),
                 shape=ft.RoundedRectangleBorder(radius=8),
                 bgcolor=bg,
-                minimum_size=ft.Size(140, 48),
             ),
             on_click=lambda e: filtro_cb(value),
         )


### PR DESCRIPTION
## Summary
- replace nonexistent ft.Size usage with width property when building filter buttons

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890e9b6d87c832284f3205c71af3ee4