### PR TITLE
replace deprecated ink widgets

### DIFF
--- a/src/ui/main_view.py
+++ b/src/ui/main_view.py
@@ -201,26 +201,23 @@ def build_data_table(
 
         actions = ft.Row(
             [
-                ft.InkWell(
-                    content=ft.Icon(ft.icons.VISIBILITY, size=20, color=ft.colors.GREY_600),
-                    on_tap=lambda e, ata=ata: visualizar_cb(ata),
-                    hover_color=ft.colors.with_opacity(0.1, ft.colors.GREY_200),
-                    splash_color=ft.colors.with_opacity(0.1, ft.colors.GREY_400),
-                    border_radius=8,
+                ft.IconButton(
+                    icon=ft.icons.VISIBILITY,
+                    icon_size=20,
+                    icon_color=ft.colors.GREY_600,
+                    on_click=lambda e, ata=ata: visualizar_cb(ata),
                 ),
-                ft.InkWell(
-                    content=ft.Icon(ft.icons.EDIT, size=20, color=ft.colors.GREY_600),
-                    on_tap=lambda e, ata=ata: editar_cb(ata),
-                    hover_color=ft.colors.with_opacity(0.1, ft.colors.GREY_200),
-                    splash_color=ft.colors.with_opacity(0.1, ft.colors.GREY_400),
-                    border_radius=8,
+                ft.IconButton(
+                    icon=ft.icons.EDIT,
+                    icon_size=20,
+                    icon_color=ft.colors.GREY_600,
+                    on_click=lambda e, ata=ata: editar_cb(ata),
                 ),
-                ft.InkWell(
-                    content=ft.Icon(ft.icons.DELETE, size=20, color=ft.colors.GREY_600),
-                    on_tap=lambda e, ata=ata: excluir_cb(ata),
-                    hover_color=ft.colors.with_opacity(0.1, ft.colors.GREY_200),
-                    splash_color=ft.colors.with_opacity(0.1, ft.colors.GREY_400),
-                    border_radius=8,
+                ft.IconButton(
+                    icon=ft.icons.DELETE,
+                    icon_size=20,
+                    icon_color=ft.colors.GREY_600,
+                    on_click=lambda e, ata=ata: excluir_cb(ata),
                 ),
             ],
             alignment=ft.MainAxisAlignment.CENTER,


### PR DESCRIPTION
## Summary
- replace deprecated ft.InkWell with ft.IconButton in ata listing table

## Testing
- `python test_imports.py`


------
https://chatgpt.com/codex/tasks/task_e_6890eb14966883229c7ed2c972099417