### PR TITLE
fix: remove unsupported no_wrap property

### DIFF
--- a/src/ui/main_view.py
+++ b/src/ui/main_view.py
@@ -116,7 +116,6 @@ def build_filters(filtro_atual: str, filtro_cb: Callable[[str], None]) -> ft.Con
                 padding=ft.padding.symmetric(horizontal=SPACE_3, vertical=SPACE_2),
                 shape=ft.RoundedRectangleBorder(radius=8),
                 text_style=ft.TextStyle(
-                    no_wrap=True,
                     weight=ft.FontWeight.W_500,
                 ),
             ),


### PR DESCRIPTION
## Summary
- remove invalid `no_wrap` argument from `TextStyle` used in filter button

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890f7bccd0083228ca18c8435e5b5b0