### PR TITLE
fix: improve chip layout and table alignment

### DIFF
--- a/src/ui/ata_detail_view.py
+++ b/src/ui/ata_detail_view.py
@@ -149,12 +149,28 @@ def build_ata_detail_view(
     item_rows = [
         ft.DataRow(
             cells=[
-                ft.DataCell(ft.Text(item.descricao)),
-                ft.DataCell(ft.Text(str(item.quantidade))),
-                ft.DataCell(ft.Text(Formatters.formatar_valor_monetario(item.valor))),
                 ft.DataCell(
                     ft.Text(
-                        Formatters.formatar_valor_monetario(item.valor_total)
+                        item.descricao,
+                        text_align=ft.TextAlign.START,
+                    )
+                ),
+                ft.DataCell(
+                    ft.Text(
+                        str(item.quantidade),
+                        text_align=ft.TextAlign.END,
+                    )
+                ),
+                ft.DataCell(
+                    ft.Text(
+                        Formatters.formatar_valor_monetario(item.valor),
+                        text_align=ft.TextAlign.END,
+                    )
+                ),
+                ft.DataCell(
+                    ft.Text(
+                        Formatters.formatar_valor_monetario(item.valor_total),
+                        text_align=ft.TextAlign.END,
                     )
                 ),
             ]
@@ -164,15 +180,36 @@ def build_ata_detail_view(
 
     itens_table = ft.DataTable(
         columns=[
-            ft.DataColumn(ft.Text("Descrição", weight=ft.FontWeight.W_600)),
             ft.DataColumn(
-                ft.Text("Qtd.", weight=ft.FontWeight.W_600), numeric=True
+                ft.Text(
+                    "Descrição",
+                    weight=ft.FontWeight.W_600,
+                    text_align=ft.TextAlign.START,
+                )
             ),
             ft.DataColumn(
-                ft.Text("Valor Unit.", weight=ft.FontWeight.W_600), numeric=True
+                ft.Text(
+                    "Qtd.",
+                    weight=ft.FontWeight.W_600,
+                    text_align=ft.TextAlign.END,
+                ),
+                numeric=True,
             ),
             ft.DataColumn(
-                ft.Text("Subtotal", weight=ft.FontWeight.W_600), numeric=True
+                ft.Text(
+                    "Valor Unit.",
+                    weight=ft.FontWeight.W_600,
+                    text_align=ft.TextAlign.END,
+                ),
+                numeric=True,
+            ),
+            ft.DataColumn(
+                ft.Text(
+                    "Subtotal",
+                    weight=ft.FontWeight.W_600,
+                    text_align=ft.TextAlign.END,
+                ),
+                numeric=True,
             ),
         ],
         rows=item_rows,

--- a/src/ui/main_view.py
+++ b/src/ui/main_view.py
@@ -104,18 +104,30 @@ def build_filters(filtro_atual: str, filtro_cb: Callable[[str], None]) -> ft.Con
         label: str, value: str, color: str, icon: str, icon_color: str | None = None
     ) -> ft.ElevatedButton:
         selected = filtro_atual == value
+        content = ft.Row(
+            [
+                ft.Icon(icon, color=icon_color),
+                ft.Text(
+                    label,
+                    no_wrap=True,
+                    max_lines=1,
+                    overflow=ft.TextOverflow.ELLIPSIS,
+                ),
+            ],
+            spacing=SPACE_2,
+            alignment=ft.MainAxisAlignment.CENTER,
+            vertical_alignment=ft.CrossAxisAlignment.CENTER,
+        )
         return ft.ElevatedButton(
-            label,
-            icon=icon,
-            icon_color=icon_color,
+            content=content,
             on_click=lambda e: filtro_cb(value),
             bgcolor=color if selected else ft.colors.SURFACE_VARIANT,
             color=ft.colors.WHITE if selected else ft.colors.BLACK,
-            width=100,
             style=ft.ButtonStyle(
                 padding=ft.padding.symmetric(horizontal=SPACE_3, vertical=SPACE_2),
                 shape=ft.RoundedRectangleBorder(radius=8),
             ),
+            expand=True,
         )
 
     buttons: list[ft.ElevatedButton] = []


### PR DESCRIPTION
## Summary
- keep filter chips on a single line with centered icon and text
- align DataTable headers and cells consistently

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890fc8b983c8322a854d26c9435832a