### PR TITLE
feat: centralize atas tables

### DIFF
--- a/src/main_gui.py
+++ b/src/main_gui.py
@@ -117,6 +117,7 @@ class AtaApp:
             self.visualizar_ata,
             self.editar_ata,
             self.excluir_ata,
+            self.page.width,
             filtro=self.filtro_atual,
         )
         return ft.Column([filtros_search_row, self.grouped_tables], spacing=0, expand=True)
@@ -181,6 +182,7 @@ class AtaApp:
             self.visualizar_ata,
             self.editar_ata,
             self.excluir_ata,
+            self.page.width,
             filtro=self.filtro_atual,
         )
         self.grouped_tables.content = new_table.content

--- a/src/ui/__init__.py
+++ b/src/ui/__init__.py
@@ -1,2 +1,4 @@
 from .ata_detail_view import build_ata_detail_view
 from .responsive import get_breakpoint, get_padding, get_font_size
+
+from .atas_table import AtasTable

--- a/src/ui/ata_detail_view.py
+++ b/src/ui/ata_detail_view.py
@@ -30,9 +30,11 @@ except Exception:  # pragma: no cover
 try:
     from ..models.ata import Ata
     from ..utils.validators import Formatters
+    from .atas_table import AtasTable
 except ImportError:  # standalone execution
     from models.ata import Ata
     from utils.validators import Formatters
+    from atas_table import AtasTable
 
 
 def build_ata_detail_view(
@@ -146,76 +148,23 @@ def build_ata_detail_view(
         dados_gerais_body,
     )
 
-    item_rows = [
-        ft.DataRow(
-            cells=[
-                ft.DataCell(
-                    ft.Text(
-                        item.descricao,
-                        text_align=ft.TextAlign.START,
-                    )
-                ),
-                ft.DataCell(
-                    ft.Text(
-                        str(item.quantidade),
-                        text_align=ft.TextAlign.END,
-                    )
-                ),
-                ft.DataCell(
-                    ft.Text(
-                        Formatters.formatar_valor_monetario(item.valor),
-                        text_align=ft.TextAlign.END,
-                    )
-                ),
-                ft.DataCell(
-                    ft.Text(
-                        Formatters.formatar_valor_monetario(item.valor_total),
-                        text_align=ft.TextAlign.END,
-                    )
-                ),
-            ]
+    item_rows: list[dict] = []
+    for item in ata.itens:
+        item_rows.append(
+            {
+                "values": [
+                    item.descricao,
+                    str(item.quantidade),
+                    Formatters.formatar_valor_monetario(item.valor),
+                    Formatters.formatar_valor_monetario(item.valor_total),
+                ]
+            }
         )
-        for item in ata.itens
-    ]
 
-    itens_table = ft.DataTable(
-        columns=[
-            ft.DataColumn(
-                ft.Text(
-                    "Descrição",
-                    weight=ft.FontWeight.W_600,
-                    text_align=ft.TextAlign.START,
-                )
-            ),
-            ft.DataColumn(
-                ft.Text(
-                    "Qtd.",
-                    weight=ft.FontWeight.W_600,
-                    text_align=ft.TextAlign.END,
-                ),
-                numeric=True,
-            ),
-            ft.DataColumn(
-                ft.Text(
-                    "Valor Unit.",
-                    weight=ft.FontWeight.W_600,
-                    text_align=ft.TextAlign.END,
-                ),
-                numeric=True,
-            ),
-            ft.DataColumn(
-                ft.Text(
-                    "Subtotal",
-                    weight=ft.FontWeight.W_600,
-                    text_align=ft.TextAlign.END,
-                ),
-                numeric=True,
-            ),
-        ],
-        rows=item_rows,
-        heading_row_height=32,
-        data_row_min_height=32,
-        column_spacing=SPACE_3,
+    itens_table = AtasTable(
+        ["Descrição", "Qtd.", "Valor Unit.", "Subtotal"],
+        item_rows,
+        page_width=1000,
     )
 
     resumo_financeiro = ft.Container(

--- a/src/ui/atas_table.py
+++ b/src/ui/atas_table.py
@@ -1,0 +1,173 @@
+import flet as ft
+from typing import Any, Callable, List, Optional
+
+
+class AtasTable(ft.UserControl):
+    """Reusable table component for Ata listings with centralized style."""
+
+    def __init__(
+        self,
+        columns: List[str],
+        rows: List[Any],
+        on_view: Optional[Callable[[Any], None]] = None,
+        on_edit: Optional[Callable[[Any], None]] = None,
+        on_delete: Optional[Callable[[Any], None]] = None,
+        *,
+        page_width: float = 1000.0,
+    ) -> None:
+        super().__init__()
+        self.columns = columns
+        self.rows = rows
+        self.on_view = on_view
+        self.on_edit = on_edit
+        self.on_delete = on_delete
+        self.page_width = page_width
+
+    # ------------------------------------------------------------------
+    def build(self) -> ft.Control:  # pragma: no cover - UI code
+        font_size = 12 if self.page_width < 768 else 14
+
+        data_columns: List[ft.DataColumn] = []
+        for col in self.columns:
+            expand = 2 if col.upper() in ("OBJETO", "FORNECEDOR") else 1
+            data_columns.append(
+                ft.DataColumn(
+                    label=ft.Container(
+                        ft.Text(
+                            col.upper(),
+                            text_align=ft.TextAlign.CENTER,
+                            weight=ft.FontWeight.SEMIBOLD,
+                            size=font_size,
+                        ),
+                        alignment=ft.alignment.center,
+                        expand=expand,
+                    )
+                )
+            )
+
+        if any([self.on_view, self.on_edit, self.on_delete]):
+            data_columns.append(
+                ft.DataColumn(
+                    label=ft.Container(
+                        ft.Text(
+                            "AÇÕES",
+                            text_align=ft.TextAlign.CENTER,
+                            weight=ft.FontWeight.SEMIBOLD,
+                            size=font_size,
+                        ),
+                        alignment=ft.alignment.center,
+                        expand=1,
+                    )
+                )
+            )
+
+        data_rows: List[ft.DataRow] = []
+        for row in self.rows:
+            if isinstance(row, dict):
+                values = row.get("values", [])
+                data = row.get("data", row.get("values"))
+            else:
+                values = row
+                data = row
+
+            cells: List[ft.DataCell] = []
+            for col, value in zip(self.columns, values):
+                expand = 2 if col.upper() in ("OBJETO", "FORNECEDOR") else 1
+                if isinstance(value, ft.Control):
+                    cell_content = value
+                else:
+                    cell_content = ft.Text(
+                        str(value),
+                        text_align=ft.TextAlign.CENTER,
+                        overflow=ft.TextOverflow.ELLIPSIS,
+                        size=font_size,
+                    )
+                cells.append(
+                    ft.DataCell(
+                        ft.Container(
+                            cell_content,
+                            alignment=ft.alignment.center,
+                            expand=expand,
+                        )
+                    )
+                )
+
+            if any([self.on_view, self.on_edit, self.on_delete]):
+                icons: List[ft.Control] = []
+                if self.on_view:
+                    icons.append(
+                        ft.IconButton(
+                            icon=ft.icons.VISIBILITY,
+                            tooltip="Visualizar",
+                            on_click=lambda e, d=data: self.on_view(d),
+                            adaptive=True,
+                            style=ft.ButtonStyle(
+                                color={
+                                    ft.MaterialState.HOVERED: ft.colors.INDIGO_600,
+                                    "": ft.colors.GREY_700,
+                                }
+                            ),
+                        )
+                    )
+                if self.on_edit:
+                    icons.append(
+                        ft.IconButton(
+                            icon=ft.icons.EDIT,
+                            tooltip="Editar",
+                            on_click=lambda e, d=data: self.on_edit(d),
+                            adaptive=True,
+                            style=ft.ButtonStyle(
+                                color={
+                                    ft.MaterialState.HOVERED: ft.colors.INDIGO_600,
+                                    "": ft.colors.GREY_700,
+                                }
+                            ),
+                        )
+                    )
+                if self.on_delete:
+                    icons.append(
+                        ft.IconButton(
+                            icon=ft.icons.DELETE,
+                            tooltip="Excluir",
+                            on_click=lambda e, d=data: self.on_delete(d),
+                            adaptive=True,
+                            style=ft.ButtonStyle(
+                                color={
+                                    ft.MaterialState.HOVERED: ft.colors.INDIGO_600,
+                                    "": ft.colors.GREY_700,
+                                }
+                            ),
+                        )
+                    )
+                action_row = ft.Row(
+                    icons, alignment=ft.MainAxisAlignment.CENTER, spacing=4
+                )
+                cells.append(
+                    ft.DataCell(
+                        ft.Container(
+                            action_row,
+                            alignment=ft.alignment.center,
+                            expand=1,
+                        )
+                    )
+                )
+
+            data_rows.append(ft.DataRow(cells=cells))
+
+        table = ft.DataTable(
+            columns=data_columns,
+            rows=data_rows,
+            data_row_min_height=48,
+            heading_row_height=48,
+            column_spacing=0,
+            horizontal_margin=16,
+            vertical_lines=ft.BorderSide(0, "transparent"),
+            heading_row_color=ft.colors.WHITE,
+            border=ft.border.all(1, ft.colors.GREY_100),
+            vertical_alignment=ft.CrossAxisAlignment.CENTER,
+            data_row_color={
+                ft.MaterialState.HOVERED: ft.colors.GREY_100,
+                "": ft.colors.WHITE,
+            },
+        )
+        return table

--- a/src/ui/main_view.py
+++ b/src/ui/main_view.py
@@ -28,10 +28,12 @@ try:
     from ..models.ata import Ata
     from ..utils.validators import Formatters
     from ..utils.chart_utils import ChartUtils
+    from .atas_table import AtasTable
 except ImportError:  # for standalone execution
     from models.ata import Ata
     from utils.validators import Formatters
     from utils.chart_utils import ChartUtils
+    from atas_table import AtasTable
 
 
 STATUS_INFO = {
@@ -185,9 +187,9 @@ def build_data_table(
     visualizar_cb: Callable[[Ata], None],
     editar_cb: Callable[[Ata], None],
     excluir_cb: Callable[[Ata], None],
-    status: str,
-) -> ft.Column:
-    """Return custom table for a list of atas respecting design specs."""
+    page_width: float,
+) -> ft.Control:
+    """Return table for a list of atas using the standard ``AtasTable`` component."""
     if not atas:
         return ft.Container(
             content=ft.Text(
@@ -199,67 +201,16 @@ def build_data_table(
             padding=ft.padding.all(SPACE_4),
         )
 
-    header_labels = ["Número", "Vigência", "Objeto", "Fornecedor", "Situação", "Ações"]
-
-    header_cells = [
-        ft.Container(
-            ft.Text(
-                lbl.upper(),
-                size=11,
-                weight=ft.FontWeight.W_600,
-                color="#6B7280",
-                no_wrap=True,
-            ),
-            expand=1,
-            alignment=ft.alignment.center_left,
-        )
-        for lbl in header_labels
-    ]
-    header_row = ft.Container(
-        content=ft.Row(header_cells, spacing=SPACE_4),
-        padding=ft.padding.symmetric(vertical=SPACE_4, horizontal=SPACE_4),
-        bgcolor="#F9FAFB",
-        border=ft.border.only(bottom=ft.BorderSide(1, "#E5E7EB")),
-    )
-
+    columns = ["Número", "Vigência", "Objeto", "Fornecedor", "Situação"]
     badge_colors = {
         "vigente": ("#14532D", "#D1FAE5"),
         "a_vencer": ("#713F12", "#FEF9C3"),
         "vencida": ("#991B1B", "#FEE2E2"),
     }
 
-    rows: list[ft.Control] = []
-    total = len(atas)
-    for index, ata in enumerate(atas):
+    rows: list[dict] = []
+    for ata in atas:
         data_formatada = Formatters.formatar_data_brasileira(ata.data_vigencia)
-        text_cells = [
-            ft.Text(
-                ata.numero_ata,
-                weight=ft.FontWeight.W_500,
-                color="#111827",
-                max_lines=1,
-                no_wrap=True,
-                overflow=ft.TextOverflow.ELLIPSIS,
-            ),
-            ft.Text(
-                data_formatada,
-                max_lines=1,
-                no_wrap=True,
-                overflow=ft.TextOverflow.ELLIPSIS,
-            ),
-            ft.Text(
-                ata.objeto,
-                max_lines=1,
-                no_wrap=True,
-                overflow=ft.TextOverflow.ELLIPSIS,
-            ),
-            ft.Text(
-                ata.fornecedor,
-                max_lines=1,
-                no_wrap=True,
-                overflow=ft.TextOverflow.ELLIPSIS,
-            ),
-        ]
         badge_text_color, badge_bg_color = badge_colors[ata.status]
         badge = ft.Container(
             ft.Text(
@@ -274,95 +225,27 @@ def build_data_table(
             border_radius=6,
         )
 
-        actions = ft.Row(
-            [
-                ft.IconButton(
-                    icon=ft.icons.VISIBILITY,
-                    tooltip="Visualizar",
-                    on_click=lambda e, ata=ata: visualizar_cb(ata),
-                    style=ft.ButtonStyle(
-                        color={ft.MaterialState.HOVERED: "#2563EB", "": "#6B7280"}
-                    ),
-                    icon_size=20,
-                ),
-                ft.IconButton(
-                    icon=ft.icons.EDIT,
-                    tooltip="Editar",
-                    on_click=lambda e, ata=ata: editar_cb(ata),
-                    style=ft.ButtonStyle(
-                        color={ft.MaterialState.HOVERED: "#CA8A04", "": "#6B7280"}
-                    ),
-                    icon_size=20,
-                ),
-                ft.IconButton(
-                    icon=ft.icons.DELETE,
-                    tooltip="Excluir",
-                    on_click=lambda e, ata=ata: excluir_cb(ata),
-                    style=ft.ButtonStyle(
-                        color={ft.MaterialState.HOVERED: "#DC2626", "": "#6B7280"}
-                    ),
-                    icon_size=20,
-                ),
-            ],
-            spacing=SPACE_3,
-            alignment=ft.MainAxisAlignment.CENTER,
-            vertical_alignment=ft.CrossAxisAlignment.CENTER,
+        rows.append(
+            {
+                "values": [
+                    ata.numero_ata,
+                    data_formatada,
+                    ata.objeto,
+                    ata.fornecedor,
+                    badge,
+                ],
+                "data": ata,
+            }
         )
 
-        cells = [
-            ft.Container(
-                text_cells[0],
-                expand=1,
-                alignment=ft.alignment.center_left,
-            ),
-            ft.Container(
-                text_cells[1],
-                expand=1,
-                alignment=ft.alignment.center_left,
-            ),
-            ft.Container(
-                text_cells[2],
-                expand=2,
-                alignment=ft.alignment.center_left,
-            ),
-            ft.Container(
-                text_cells[3],
-                expand=1,
-                alignment=ft.alignment.center_left,
-            ),
-            ft.Container(
-                badge,
-                expand=1,
-                alignment=ft.alignment.center,
-            ),
-            ft.Container(
-                actions,
-                expand=1,
-                alignment=ft.alignment.center,
-            ),
-        ]
-
-        row_container = ft.Container(
-            content=ft.Row(
-                cells,
-                spacing=SPACE_3,
-                vertical_alignment=ft.CrossAxisAlignment.CENTER,
-            ),
-            padding=ft.padding.all(SPACE_4),
-            border=ft.border.only(bottom=ft.BorderSide(1, "#E5E7EB")) if index < total - 1 else None,
-        )
-
-        rows.append(row_container)
-
-    body = ft.Column(rows, spacing=0)
-
-    table = ft.Container(
-        content=ft.Column([header_row, body], spacing=0),
-        border=ft.border.all(1, "#E5E7EB"),
-        clip_behavior=ft.ClipBehavior.HARD_EDGE,
+    return AtasTable(
+        columns,
+        rows,
+        visualizar_cb,
+        editar_cb,
+        excluir_cb,
+        page_width=page_width,
     )
-
-    return table
 
 
 def build_grouped_data_tables(
@@ -370,6 +253,7 @@ def build_grouped_data_tables(
     visualizar_cb: Callable[[Ata], None],
     editar_cb: Callable[[Ata], None],
     excluir_cb: Callable[[Ata], None],
+    page_width: float,
     filtro: str = "todos",
 ) -> ft.Container:
     """Return layout with status cards for the given ``atas`` respecting ``filtro``.
@@ -412,7 +296,7 @@ def build_grouped_data_tables(
             visualizar_cb,
             editar_cb,
             excluir_cb,
-            status,
+            page_width,
         )
 
         card = build_card(info["title"], icon, table)


### PR DESCRIPTION
## Summary
- introduce reusable AtasTable component with centralized headers, cells and action icons
- replace custom tables with AtasTable for consistent style and responsiveness
- apply responsive width handling when building tables

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6890ff56e7e88322952992dd60802f0b