### PR TITLE
Fix unsupported FontWeight constant in AtasTable

### DIFF
--- a/src/ui/atas_table.py
+++ b/src/ui/atas_table.py
@@ -33,12 +33,12 @@ class AtasTable(ft.UserControl):
             data_columns.append(
                 ft.DataColumn(
                     label=ft.Container(
-                        ft.Text(
-                            col.upper(),
-                            text_align=ft.TextAlign.CENTER,
-                            weight=ft.FontWeight.SEMIBOLD,
-                            size=font_size,
-                        ),
+                            ft.Text(
+                                col.upper(),
+                                text_align=ft.TextAlign.CENTER,
+                            weight=ft.FontWeight.W_600,
+                                size=font_size,
+                            ),
                         alignment=ft.alignment.center,
                         expand=expand,
                     )
@@ -52,7 +52,7 @@ class AtasTable(ft.UserControl):
                         ft.Text(
                             "AÇÕES",
                             text_align=ft.TextAlign.CENTER,
-                            weight=ft.FontWeight.SEMIBOLD,
+                            weight=ft.FontWeight.W_600,
                             size=font_size,
                         ),
                         alignment=ft.alignment.center,


### PR DESCRIPTION
## Summary
- replace nonexistent `FontWeight.SEMIBOLD` with supported `FontWeight.W_600`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689103a75b648322ac694ce497b82b53