### PR TITLE
fix: remove unsupported vertical alignment

### DIFF
--- a/src/ui/atas_table.py
+++ b/src/ui/atas_table.py
@@ -164,7 +164,6 @@ class AtasTable(ft.UserControl):
             vertical_lines=ft.BorderSide(0, "transparent"),
             heading_row_color=ft.colors.WHITE,
             border=ft.border.all(1, ft.colors.GREY_100),
-            vertical_alignment=ft.CrossAxisAlignment.CENTER,
             data_row_color={
                 ft.MaterialState.HOVERED: ft.colors.GREY_100,
                 "": ft.colors.WHITE,


### PR DESCRIPTION
## Summary
- remove unsupported `vertical_alignment` parameter from `DataTable`

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891049f611c832293cce979f239b206