### PR TITLE
Padroniza botões com estilo unificado

### DIFF
--- a/src/forms/ata_form.py
+++ b/src/forms/ata_form.py
@@ -11,6 +11,8 @@ try:
         build_section,
         primary_button,
         secondary_button,
+        text_button,
+        icon_button,
     )
 except Exception:  # pragma: no cover
     from ui.tokens import (
@@ -21,6 +23,8 @@ except Exception:  # pragma: no cover
         build_section,
         primary_button,
         secondary_button,
+        text_button,
+        icon_button,
     )
 try:
     from ..models.ata import Ata, Item
@@ -137,8 +141,8 @@ class AtaForm:
             dados_gerais_body,
         )
         
-        telefones_header_btn = ft.IconButton(
-            icon=ft.icons.ADD,
+        telefones_header_btn = icon_button(
+            ft.icons.ADD,
             tooltip="Adicionar telefone",
             on_click=lambda e: self.add_telefone(),
         )
@@ -155,8 +159,8 @@ class AtaForm:
             ], spacing=SPACE_2),
         )
         
-        emails_header_btn = ft.IconButton(
-            icon=ft.icons.ADD,
+        emails_header_btn = icon_button(
+            ft.icons.ADD,
             tooltip="Adicionar e-mail",
             on_click=lambda e: self.add_email(),
         )
@@ -173,8 +177,8 @@ class AtaForm:
             ], spacing=SPACE_2),
         )
         
-        itens_header_btn = ft.IconButton(
-            icon=ft.icons.ADD,
+        itens_header_btn = icon_button(
+            ft.icons.ADD,
             tooltip="Adicionar item",
             on_click=lambda e: self.add_item(),
         )
@@ -287,9 +291,9 @@ class AtaForm:
             width=200
         )
         
-        remove_btn = ft.IconButton(
-            icon=ft.icons.DELETE,
-            tooltip="Remover telefone"
+        remove_btn = icon_button(
+            ft.icons.DELETE,
+            tooltip="Remover telefone",
         )
 
         row = ft.Row([telefone_field, remove_btn], spacing=SPACE_2)
@@ -314,9 +318,9 @@ class AtaForm:
             width=300
         )
         
-        remove_btn = ft.IconButton(
-            icon=ft.icons.DELETE,
-            tooltip="Remover e-mail"
+        remove_btn = icon_button(
+            ft.icons.DELETE,
+            tooltip="Remover e-mail",
         )
 
         row = ft.Row([email_field, remove_btn], spacing=SPACE_2)
@@ -355,10 +359,10 @@ class AtaForm:
             width=150
         )
         
-        remove_btn = ft.IconButton(
-            icon=ft.icons.DELETE,
+        remove_btn = icon_button(
+            ft.icons.DELETE,
             tooltip="Remover item",
-            on_click=lambda e: self.remove_item(descricao_field, row)
+            on_click=lambda e: self.remove_item(descricao_field, row),
         )
         
         row = ft.Row([
@@ -483,7 +487,7 @@ class AtaForm:
                     ft.Text("Corrija os seguintes erros:"),
                     *[ft.Text(f"• {erro}") for erro in erros]
                 ], tight=True),
-                actions=[ft.TextButton("OK", on_click=lambda e: self.close_error_dialog())]
+                actions=[text_button("OK", on_click=lambda e: self.close_error_dialog())]
             )
             self.page.dialog = erro_dialog
             erro_dialog.open = True

--- a/src/main_gui.py
+++ b/src/main_gui.py
@@ -20,7 +20,7 @@ from ui.main_view import (
 )
 from ui.navigation_menu import LeftNavigationMenu
 from ui import build_ata_detail_view
-from ui.tokens import SPACE_4
+from ui.tokens import SPACE_4, text_button
 from ui.responsive import get_breakpoint
 
 class AtaApp:
@@ -231,8 +231,8 @@ class AtaApp:
             title=ft.Text("Excluir Ata"),
             content=ft.Text(f"Deseja realmente excluir a ata {ata.numero_ata}?"),
             actions=[
-                ft.TextButton("Cancelar", on_click=lambda e: self.close_dialog()),
-                ft.TextButton("Excluir", on_click=lambda e: self.confirmar_exclusao(ata.numero_ata))
+                text_button("Cancelar", on_click=lambda e: self.close_dialog()),
+                text_button("Excluir", on_click=lambda e: self.confirmar_exclusao(ata.numero_ata))
             ]
         )
         self.page.dialog.open = True
@@ -253,7 +253,7 @@ class AtaApp:
             self.page.dialog = ft.AlertDialog(
                 title=ft.Text("Alerta Enviado"),
                 content=ft.Text("Alerta de vencimento enviado com sucesso!\n(Verifique o console para detalhes)"),
-                actions=[ft.TextButton("OK", on_click=lambda e: self.close_dialog())]
+                actions=[text_button("OK", on_click=lambda e: self.close_dialog())]
             )
             self.page.dialog.open = True
             self.page.update()
@@ -294,7 +294,7 @@ class AtaApp:
         self.page.dialog = ft.AlertDialog(
             title=ft.Text("Sucesso"),
             content=ft.Text(message),
-            actions=[ft.TextButton("OK", on_click=lambda e: self.close_dialog())]
+            actions=[text_button("OK", on_click=lambda e: self.close_dialog())]
         )
         self.page.dialog.open = True
         self.page.update()
@@ -304,7 +304,7 @@ class AtaApp:
         self.page.dialog = ft.AlertDialog(
             title=ft.Text("Erro"),
             content=ft.Text(message),
-            actions=[ft.TextButton("OK", on_click=lambda e: self.close_dialog())]
+            actions=[text_button("OK", on_click=lambda e: self.close_dialog())]
         )
         self.page.dialog.open = True
         self.page.update()
@@ -337,7 +337,7 @@ class AtaApp:
         self.page.dialog = ft.AlertDialog(
             title=ft.Text("Verificação de Alertas"),
             content=ft.Text(message),
-            actions=[ft.TextButton("OK", on_click=lambda e: self.close_dialog())]
+            actions=[text_button("OK", on_click=lambda e: self.close_dialog())]
         )
         self.page.dialog.open = True
         self.page.update()
@@ -352,7 +352,7 @@ class AtaApp:
         self.page.dialog = ft.AlertDialog(
             title=ft.Text(f"Relatório {tipo.title()}"),
             content=ft.Text(message),
-            actions=[ft.TextButton("OK", on_click=lambda e: self.close_dialog())]
+            actions=[text_button("OK", on_click=lambda e: self.close_dialog())]
         )
         self.page.dialog.open = True
         self.page.update()
@@ -367,7 +367,7 @@ class AtaApp:
         self.page.dialog = ft.AlertDialog(
             title=ft.Text("Teste de Email"),
             content=ft.Text(message),
-            actions=[ft.TextButton("OK", on_click=lambda e: self.close_dialog())]
+            actions=[text_button("OK", on_click=lambda e: self.close_dialog())]
         )
         self.page.dialog.open = True
         self.page.update()
@@ -394,7 +394,7 @@ O sistema está monitorando automaticamente as atas e enviará alertas conforme 
         self.page.dialog = ft.AlertDialog(
             title=ft.Text("Status do Sistema"),
             content=ft.Text(message),
-            actions=[ft.TextButton("OK", on_click=lambda e: self.close_dialog())]
+            actions=[text_button("OK", on_click=lambda e: self.close_dialog())]
         )
         self.page.dialog.open = True
         self.page.update()

--- a/src/ui/main_view.py
+++ b/src/ui/main_view.py
@@ -11,6 +11,9 @@ try:
         SPACE_6,
         build_card,
         primary_button,
+        button_style,
+        BUTTON_HEIGHT,
+        icon_button,
     )
 except Exception:  # pragma: no cover - fallback for standalone execution
     from tokens import (
@@ -22,6 +25,9 @@ except Exception:  # pragma: no cover - fallback for standalone execution
         SPACE_6,
         build_card,
         primary_button,
+        button_style,
+        BUTTON_HEIGHT,
+        icon_button,
     )
 
 try:
@@ -123,10 +129,8 @@ def build_filters(filtro_atual: str, filtro_cb: Callable[[str], None]) -> ft.Con
             on_click=lambda e: filtro_cb(value),
             bgcolor=color if selected else ft.colors.SURFACE_VARIANT,
             color=ft.colors.WHITE if selected else ft.colors.BLACK,
-            style=ft.ButtonStyle(
-                padding=ft.padding.symmetric(horizontal=SPACE_3, vertical=SPACE_2),
-                shape=ft.RoundedRectangleBorder(radius=8),
-            ),
+            height=BUTTON_HEIGHT,
+            style=button_style(),
             expand=True,
         )
 
@@ -285,32 +289,29 @@ def build_data_table(
 
         actions = ft.Row(
             [
-                ft.IconButton(
-                    icon=ft.icons.VISIBILITY,
+                icon_button(
+                    ft.icons.VISIBILITY,
                     tooltip="Visualizar",
                     on_click=lambda e, ata=ata: visualizar_cb(ata),
-                    style=ft.ButtonStyle(
+                    style=button_style(
                         color={ft.MaterialState.HOVERED: "#2563EB", "": "#6B7280"}
                     ),
-                    icon_size=20,
                 ),
-                ft.IconButton(
-                    icon=ft.icons.EDIT,
+                icon_button(
+                    ft.icons.EDIT,
                     tooltip="Editar",
                     on_click=lambda e, ata=ata: editar_cb(ata),
-                    style=ft.ButtonStyle(
+                    style=button_style(
                         color={ft.MaterialState.HOVERED: "#CA8A04", "": "#6B7280"}
                     ),
-                    icon_size=20,
                 ),
-                ft.IconButton(
-                    icon=ft.icons.DELETE,
+                icon_button(
+                    ft.icons.DELETE,
                     tooltip="Excluir",
                     on_click=lambda e, ata=ata: excluir_cb(ata),
-                    style=ft.ButtonStyle(
+                    style=button_style(
                         color={ft.MaterialState.HOVERED: "#DC2626", "": "#6B7280"}
                     ),
-                    icon_size=20,
                 ),
             ],
             spacing=SPACE_3,
@@ -484,8 +485,16 @@ def build_atas_vencimento(
                     ),
                 ], spacing=4),
                 ft.Row([
-                    ft.IconButton(icon=ft.icons.VISIBILITY, tooltip="Visualizar", on_click=lambda e, ata=ata: visualizar_cb(ata)),
-                    ft.IconButton(icon=ft.icons.EMAIL, tooltip="Enviar Alerta", on_click=lambda e, ata=ata: alerta_cb(ata)),
+                    icon_button(
+                        ft.icons.VISIBILITY,
+                        tooltip="Visualizar",
+                        on_click=lambda e, ata=ata: visualizar_cb(ata),
+                    ),
+                    icon_button(
+                        ft.icons.EMAIL,
+                        tooltip="Enviar Alerta",
+                        on_click=lambda e, ata=ata: alerta_cb(ata),
+                    ),
                 ]),
             ], alignment=ft.MainAxisAlignment.SPACE_BETWEEN),
             padding=ft.padding.all(SPACE_3),

--- a/src/ui/navigation_menu.py
+++ b/src/ui/navigation_menu.py
@@ -1,9 +1,9 @@
 import flet as ft
 
 try:
-    from .tokens import SPACE_2, SPACE_3, SPACE_5
+    from .tokens import SPACE_2, SPACE_3, SPACE_5, icon_button
 except Exception:  # pragma: no cover
-    from tokens import SPACE_2, SPACE_3, SPACE_5
+    from tokens import SPACE_2, SPACE_3, SPACE_5, icon_button
 
 class PopupColorItem(ft.PopupMenuItem):
     def __init__(self, color: str, name: str):
@@ -98,7 +98,11 @@ class LeftNavigationMenu(ft.Column):
         ]
         self.rail = NavigationColumn(app, self.destinations)
         self.dark_light_text = ft.Text("Light theme")
-        self.dark_light_icon = ft.IconButton(icon=ft.icons.BRIGHTNESS_2_OUTLINED, tooltip="Toggle brightness", on_click=self.theme_changed)
+        self.dark_light_icon = icon_button(
+            ft.icons.BRIGHTNESS_2_OUTLINED,
+            tooltip="Toggle brightness",
+            on_click=self.theme_changed,
+        )
         self.padding = SPACE_5
         self.spacing = SPACE_3
         self.controls = [

--- a/src/ui/tokens.py
+++ b/src/ui/tokens.py
@@ -15,6 +15,16 @@ WARNING = ft.colors.ORANGE
 GREY_LIGHT = ft.colors.GREY_300
 CARD_BG = "#F8FAFC"
 
+BUTTON_HEIGHT = 40
+
+
+def button_style(**kwargs) -> ft.ButtonStyle:
+    return ft.ButtonStyle(
+        padding=ft.padding.symmetric(horizontal=16, vertical=0),
+        shape=ft.RoundedRectangleBorder(radius=6),
+        **kwargs,
+    )
+
 
 def primary_button(
     text: str,
@@ -22,15 +32,15 @@ def primary_button(
     icon: Optional[str] = None,
     on_click: Optional[Callable[[ft.ControlEvent], None]] = None,
 ) -> ft.ElevatedButton:
-    """Return a standard primary button used across the app."""
-
     return ft.ElevatedButton(
         text=text,
         icon=icon,
         on_click=on_click,
         bgcolor="#3B82F6",
         color="#FFFFFF",
-        style=ft.ButtonStyle(shape=ft.RoundedRectangleBorder(radius=8)),
+        height=BUTTON_HEIGHT,
+        min_width=120,
+        style=button_style(),
     )
 
 
@@ -40,18 +50,47 @@ def secondary_button(
     icon: Optional[str] = None,
     on_click: Optional[Callable[[ft.ControlEvent], None]] = None,
 ) -> ft.OutlinedButton:
-    """Return a standard secondary button used across the app."""
-
     return ft.OutlinedButton(
         text=text,
         icon=icon,
         on_click=on_click,
-        style=ft.ButtonStyle(
-            shape=ft.RoundedRectangleBorder(radius=8),
-            color="#4B5563",
-            side=ft.BorderSide(1, "#D1D5DB"),
-        ),
+        height=BUTTON_HEIGHT,
+        style=button_style(color="#4B5563", side=ft.BorderSide(1, "#D1D5DB")),
     )
+
+
+def text_button(
+    text: str,
+    *,
+    icon: Optional[str] = None,
+    on_click: Optional[Callable[[ft.ControlEvent], None]] = None,
+) -> ft.TextButton:
+    return ft.TextButton(
+        text=text,
+        icon=icon,
+        on_click=on_click,
+        height=BUTTON_HEIGHT,
+        style=button_style(),
+    )
+
+
+def icon_button(
+    icon: str,
+    *,
+    tooltip: Optional[str] = None,
+    on_click: Optional[Callable[[ft.ControlEvent], None]] = None,
+    icon_size: int = 20,
+    style: ft.ButtonStyle | None = None,
+) -> ft.IconButton:
+    return ft.IconButton(
+        icon=icon,
+        tooltip=tooltip,
+        on_click=on_click,
+        icon_size=icon_size,
+        height=BUTTON_HEIGHT,
+        style=style or button_style(),
+    )
+
 
 def build_section(
     title: str,
@@ -60,8 +99,6 @@ def build_section(
     icon_bg: str,
     body: ft.Control,
 ) -> ft.Container:
-    """Return standard section container used across views."""
-
     header = ft.Row(
         [
             ft.Container(
@@ -82,6 +119,7 @@ def build_section(
         padding=SPACE_4,
         border_radius=12,
     )
+
 
 def build_card(title: str, icon: ft.Control, content: ft.Control) -> ft.Control:
     header = ft.Row(
@@ -110,3 +148,4 @@ def build_card(title: str, icon: ft.Control, content: ft.Control) -> ft.Control:
             offset=ft.Offset(0, 2),
         ),
     )
+


### PR DESCRIPTION
## Summary
- Centraliza estilo dos botões com altura fixa, raio de 6px e padding horizontal de 16px
- Atualiza telas para usar funções helper de botões e padronizar ações
- Substitui botões de ícone e texto por versões consistentes em toda a aplicação

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68910907e8ac8322b2adb8b381ebbe75