### PR TITLE
refactor: centralize spacing tokens

### DIFF
--- a/src/forms/ata_form.py
+++ b/src/forms/ata_form.py
@@ -3,25 +3,25 @@ from datetime import date, datetime
 from typing import List, Dict, Any, Optional, Callable
 
 try:
-    from ..ui.tokens import (
+    from ..ui.spacing import (
+        SPACE_1,
         SPACE_2,
         SPACE_3,
         SPACE_4,
         SPACE_5,
-        build_section,
-        primary_button,
-        secondary_button,
+        SPACE_6,
     )
+    from ..ui.tokens import build_section, primary_button, secondary_button
 except Exception:  # pragma: no cover
-    from ui.tokens import (
+    from ui.spacing import (
+        SPACE_1,
         SPACE_2,
         SPACE_3,
         SPACE_4,
         SPACE_5,
-        build_section,
-        primary_button,
-        secondary_button,
+        SPACE_6,
     )
+    from ui.tokens import build_section, primary_button, secondary_button
 try:
     from ..models.ata import Ata, Item
     from ..utils.validators import Validators, Formatters, MaskUtils
@@ -210,7 +210,7 @@ class AtaForm:
         header = ft.Row(
             [
                 ft.Column(
-                    spacing=2,
+                    spacing=SPACE_1,
                     controls=[
                         ft.Text(
                             "Ata de Registro de Preços",
@@ -233,7 +233,7 @@ class AtaForm:
         )
 
         card = ft.Container(
-            content=ft.Column([header, content], spacing=32, expand=True),
+            content=ft.Column([header, content], spacing=SPACE_6, expand=True),
             width=1152,
             bgcolor="#FFFFFF",
             padding=SPACE_5,

--- a/src/main_gui.py
+++ b/src/main_gui.py
@@ -20,7 +20,7 @@ from ui.main_view import (
 )
 from ui.navigation_menu import LeftNavigationMenu
 from ui import build_ata_detail_view
-from ui.tokens import SPACE_4
+from ui.spacing import SPACE_4, SPACE_5
 from ui.responsive import get_breakpoint
 
 class AtaApp:
@@ -65,7 +65,15 @@ class AtaApp:
 
         self.navigation_menu = LeftNavigationMenu(self)
         self.navigation_menu.update_layout(self.page.width)
-        self.body_container = ft.Container(expand=True)
+        self.body_container = ft.Container(
+            padding=ft.padding.only(
+                left=SPACE_5,
+                right=SPACE_5,
+                top=SPACE_4,
+                bottom=SPACE_4,
+            ),
+            expand=True,
+        )
         self.update_body()
 
         layout = ft.Row(

--- a/src/ui/ata_detail_view.py
+++ b/src/ui/ata_detail_view.py
@@ -3,29 +3,25 @@ from datetime import timedelta
 from typing import Callable
 
 try:
-    from .tokens import (
+    from .spacing import (
         SPACE_1,
         SPACE_2,
         SPACE_3,
         SPACE_4,
         SPACE_5,
         SPACE_6,
-        build_section,
-        primary_button,
-        secondary_button,
     )
+    from .tokens import build_section, primary_button, secondary_button
 except Exception:  # pragma: no cover
-    from tokens import (
+    from spacing import (
         SPACE_1,
         SPACE_2,
         SPACE_3,
         SPACE_4,
         SPACE_5,
         SPACE_6,
-        build_section,
-        primary_button,
-        secondary_button,
     )
+    from tokens import build_section, primary_button, secondary_button
 
 try:
     from ..models.ata import Ata
@@ -53,7 +49,7 @@ def build_ata_detail_view(
     header = ft.Row(
         [
             ft.Column(
-                spacing=2,
+                spacing=SPACE_1,
                 controls=[
                     ft.Text(
                         "Ata de Registro de Preços",
@@ -281,7 +277,7 @@ def build_ata_detail_view(
                     ft.Icon(ft.icons.PHONE_OUTLINED, color="#6B7280"),
                     ft.Text(tel),
                 ],
-                spacing=8,
+                spacing=SPACE_2,
             )
         )
     if ata.telefones_fornecedor:
@@ -293,11 +289,11 @@ def build_ata_detail_view(
                     ft.Icon(ft.icons.EMAIL_OUTLINED, color="#6B7280"),
                     ft.Text(email),
                 ],
-                spacing=8,
+                spacing=SPACE_2,
             )
         )
 
-    contatos_body = ft.Column(contatos_list, spacing=12)
+    contatos_body = ft.Column(contatos_list, spacing=SPACE_3)
     contatos_section = build_section(
         "Contatos",
         ft.icons.HEADSET_MIC_OUTLINED,
@@ -318,7 +314,7 @@ def build_ata_detail_view(
     card = ft.Container(
         content=ft.Column(
             [header, layout],
-            spacing=32,
+            spacing=SPACE_6,
             scroll=ft.ScrollMode.AUTO,
             expand=True,
         ),

--- a/src/ui/main_view.py
+++ b/src/ui/main_view.py
@@ -2,27 +2,25 @@ import flet as ft
 from typing import Callable, List
 
 try:
-    from .tokens import (
+    from .spacing import (
         SPACE_1,
         SPACE_2,
         SPACE_3,
         SPACE_4,
         SPACE_5,
         SPACE_6,
-        build_card,
-        primary_button,
     )
+    from .tokens import build_card, primary_button
 except Exception:  # pragma: no cover - fallback for standalone execution
-    from tokens import (
+    from spacing import (
         SPACE_1,
         SPACE_2,
         SPACE_3,
         SPACE_4,
         SPACE_5,
         SPACE_6,
-        build_card,
-        primary_button,
     )
+    from tokens import build_card, primary_button
 
 try:
     from ..models.ata import Ata
@@ -482,7 +480,7 @@ def build_atas_vencimento(
                         f"Faltam {ata.dias_restantes} dias",
                         color=ft.colors.RED if ata.dias_restantes <= 30 else ft.colors.ORANGE,
                     ),
-                ], spacing=4),
+                ], spacing=SPACE_1),
                 ft.Row([
                     ft.IconButton(icon=ft.icons.VISIBILITY, tooltip="Visualizar", on_click=lambda e, ata=ata: visualizar_cb(ata)),
                     ft.IconButton(icon=ft.icons.EMAIL, tooltip="Enviar Alerta", on_click=lambda e, ata=ata: alerta_cb(ata)),
@@ -538,7 +536,7 @@ def build_stats_panel(ata_service) -> ft.Container:
                 ),
                 ft.Row(
                     [pie_chart, legend],
-                    spacing=32,
+                    spacing=SPACE_6,
                     alignment=ft.MainAxisAlignment.START,
                 ),
                 value_chart,

--- a/src/ui/navigation_menu.py
+++ b/src/ui/navigation_menu.py
@@ -1,9 +1,9 @@
 import flet as ft
 
 try:
-    from .tokens import SPACE_2, SPACE_3, SPACE_5
+    from .spacing import SPACE_2, SPACE_3, SPACE_5
 except Exception:  # pragma: no cover
-    from tokens import SPACE_2, SPACE_3, SPACE_5
+    from spacing import SPACE_2, SPACE_3, SPACE_5
 
 class PopupColorItem(ft.PopupMenuItem):
     def __init__(self, color: str, name: str):

--- a/src/ui/spacing.py
+++ b/src/ui/spacing.py
@@ -1,0 +1,6 @@
+SPACE_1 = 4      # xs
+SPACE_2 = 8      # sm
+SPACE_3 = 12     # md
+SPACE_4 = 16     # lg
+SPACE_5 = 24     # xl  # gutter padrão
+SPACE_6 = 32     # 2xl

--- a/src/ui/tokens.py
+++ b/src/ui/tokens.py
@@ -1,9 +1,11 @@
-SPACE_1 = 4
-SPACE_2 = 8
-SPACE_3 = 12
-SPACE_4 = 16
-SPACE_5 = 24
-SPACE_6 = 32
+from .spacing import (
+    SPACE_1,
+    SPACE_2,
+    SPACE_3,
+    SPACE_4,
+    SPACE_5,
+    SPACE_6,
+)
 
 import flet as ft
 from typing import Callable, Optional

--- a/src/utils/chart_utils.py
+++ b/src/utils/chart_utils.py
@@ -8,6 +8,25 @@ try:
 except ImportError:
     from models.ata import Ata
 
+try:
+    from ..ui.spacing import (
+        SPACE_1,
+        SPACE_2,
+        SPACE_3,
+        SPACE_4,
+        SPACE_5,
+        SPACE_6,
+    )
+except Exception:  # pragma: no cover
+    from ui.spacing import (
+        SPACE_1,
+        SPACE_2,
+        SPACE_3,
+        SPACE_4,
+        SPACE_5,
+        SPACE_6,
+    )
+
 class ChartUtils:
     """Utilitários para criação de gráficos e visualizações"""
     
@@ -86,11 +105,11 @@ class ChartUtils:
                     border_radius=2
                 ),
                 ft.Text(f"{info['icon']} {info['label']}: {count} ({percentage:.1f}%)")
-            ], spacing=8)
+            ], spacing=SPACE_2)
             
             legend_items.append(item)
         
-        return ft.Column(legend_items, spacing=8)
+        return ft.Column(legend_items, spacing=SPACE_2)
     
     @staticmethod
     def create_monthly_chart(atas: List[Ata]) -> ft.Container:
@@ -139,7 +158,7 @@ class ChartUtils:
                     ),
                     ft.Text(month, size=10, text_align=ft.TextAlign.CENTER)
                 ], horizontal_alignment=ft.CrossAxisAlignment.CENTER),
-                padding=ft.padding.all(4)
+                padding=ft.padding.all(SPACE_1)
             )
             bars.append(bar)
         
@@ -147,8 +166,8 @@ class ChartUtils:
             content=ft.Column([
                 ft.Text("Vencimentos por Mês", size=14, weight=ft.FontWeight.BOLD),
                 ft.Row(bars, alignment=ft.MainAxisAlignment.SPACE_AROUND)
-            ], spacing=16),
-            padding=ft.padding.all(16),
+            ], spacing=SPACE_4),
+            padding=ft.padding.all(SPACE_4),
             border=ft.border.all(1, ft.colors.OUTLINE),
             border_radius=8
         )
@@ -167,7 +186,7 @@ class ChartUtils:
         if total_value == 0:
             return ft.Container(
                 content=ft.Text("Nenhum valor cadastrado"),
-                padding=ft.padding.all(16)
+                padding=ft.padding.all(SPACE_4)
             )
         
         # Cria barras horizontais
@@ -202,8 +221,8 @@ class ChartUtils:
                             border_radius=2
                         ),
                         ft.Text(f"{percentage:.1f}% ({value_formatted})", size=12)
-                    ], spacing=8, alignment=ft.MainAxisAlignment.START),
-                    margin=ft.margin.only(bottom=8)
+                    ], spacing=SPACE_2, alignment=ft.MainAxisAlignment.START),
+                    margin=ft.margin.only(bottom=SPACE_2)
                 )
                 bars.append(bar)
         
@@ -213,8 +232,8 @@ class ChartUtils:
                 ft.Text(f"Total: R$ {total_value:,.2f}".replace(",", "X").replace(".", ",").replace("X", "."), 
                        size=12, color=ft.colors.SECONDARY),
                 ft.Column(bars, spacing=0)
-            ], spacing=16),
-            padding=ft.padding.all(16),
+            ], spacing=SPACE_4),
+            padding=ft.padding.all(SPACE_4),
             border=ft.border.all(1, ft.colors.OUTLINE),
             border_radius=8
         )
@@ -227,8 +246,8 @@ class ChartUtils:
                 content=ft.Row([
                     ft.Icon(ft.icons.CHECK_CIRCLE, color=ft.colors.GREEN, size=24),
                     ft.Text("Nenhuma ata próxima do vencimento", color=ft.colors.GREEN)
-                ], spacing=8),
-                padding=ft.padding.all(16),
+                ], spacing=SPACE_2),
+                padding=ft.padding.all(SPACE_4),
                 border=ft.border.all(1, ft.colors.GREEN),
                 border_radius=8,
                 bgcolor=ft.colors.GREEN_50
@@ -262,9 +281,9 @@ class ChartUtils:
                 ft.Column([
                     ft.Text(message, weight=ft.FontWeight.BOLD, color=color),
                     ft.Text(f"Total de atas monitoradas: {len(atas_vencimento)}", size=12)
-                ], spacing=4)
-            ], spacing=8),
-            padding=ft.padding.all(16),
+                ], spacing=SPACE_1)
+            ], spacing=SPACE_2),
+            padding=ft.padding.all(SPACE_4),
             border=ft.border.all(1, color),
             border_radius=8,
             bgcolor=bgcolor
@@ -298,9 +317,9 @@ class ChartUtils:
                     ),
                 ],
                 horizontal_alignment=ft.CrossAxisAlignment.CENTER,
-                spacing=4,
+                spacing=SPACE_1,
             ),
-            padding=ft.padding.all(16),
+            padding=ft.padding.all(SPACE_4),
             border=ft.border.all(1, ft.colors.OUTLINE),
             border_radius=8,
             bgcolor=ft.colors.SURFACE_VARIANT,
@@ -330,9 +349,9 @@ class ChartUtils:
                     ),
                 ],
                 horizontal_alignment=ft.CrossAxisAlignment.CENTER,
-                spacing=4,
+                spacing=SPACE_1,
             ),
-            padding=ft.padding.all(16),
+            padding=ft.padding.all(SPACE_4),
             border=ft.border.all(1, ft.colors.OUTLINE),
             border_radius=8,
             bgcolor=ft.colors.SURFACE_VARIANT,
@@ -367,9 +386,9 @@ class ChartUtils:
                     ),
                 ],
                 horizontal_alignment=ft.CrossAxisAlignment.CENTER,
-                spacing=4,
+                spacing=SPACE_1,
             ),
-            padding=ft.padding.all(16),
+            padding=ft.padding.all(SPACE_4),
             border=ft.border.all(1, ft.colors.GREEN),
             border_radius=8,
             bgcolor=ft.colors.GREEN_50,
@@ -404,9 +423,9 @@ class ChartUtils:
                     ),
                 ],
                 horizontal_alignment=ft.CrossAxisAlignment.CENTER,
-                spacing=4,
+                spacing=SPACE_1,
             ),
-            padding=ft.padding.all(16),
+            padding=ft.padding.all(SPACE_4),
             border=ft.border.all(1, ft.colors.ORANGE),
             border_radius=8,
             bgcolor=ft.colors.ORANGE_50,
@@ -414,5 +433,5 @@ class ChartUtils:
         )
         cards.append(card_vencer)
 
-        return ft.Row(cards, spacing=16, alignment=ft.MainAxisAlignment.SPACE_EVENLY)
+        return ft.Row(cards, spacing=SPACE_4, alignment=ft.MainAxisAlignment.SPACE_EVENLY)
 


### PR DESCRIPTION
## Summary
- define spacing tokens in dedicated module and consume across UI
- apply spacing-based padding to root content container
- replace hardcoded margins and padding with tokens

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68910b21a0408322968efd0a10d7fb01