### PR TITLE
Normalize gutter spacing with design tokens

### DIFF
--- a/src/forms/ata_form.py
+++ b/src/forms/ata_form.py
@@ -234,9 +234,13 @@ class AtaForm:
 
         card = ft.Container(
             content=ft.Column([header, content], spacing=SPACE_6, expand=True),
-            width=1152,
             bgcolor="#FFFFFF",
-            padding=SPACE_5,
+            padding=ft.padding.only(
+                left=SPACE_5,
+                right=SPACE_5,
+                top=SPACE_4,
+                bottom=SPACE_4,
+            ),
             border_radius=16,
             alignment=ft.alignment.center,
             shadow=ft.BoxShadow(
@@ -246,6 +250,7 @@ class AtaForm:
                 offset=ft.Offset(0, 5),
             ),
             expand=True,
+            max_width=1152,
         )
 
         self.dialog = ft.AlertDialog(content=card, modal=True)

--- a/src/main_gui.py
+++ b/src/main_gui.py
@@ -46,7 +46,8 @@ class AtaApp:
         self.page.window_width = 1200
         self.page.window_height = 800
         self.page.theme_mode = ft.ThemeMode.LIGHT
-        self.page.padding = SPACE_4
+        # Remove outer page padding to ensure consistent gutter handled by body container
+        self.page.padding = 0
         self.page.bgcolor = "#F3F4F6"
         self.page.fonts = {"Inter": "https://fonts.gstatic.com/s/inter/v7/Inter-Regular.ttf"}
         self.page.theme = ft.Theme(font_family="Inter")

--- a/src/ui/ata_detail_view.py
+++ b/src/ui/ata_detail_view.py
@@ -318,9 +318,13 @@ def build_ata_detail_view(
             scroll=ft.ScrollMode.AUTO,
             expand=True,
         ),
-        width=1152,
         bgcolor="#FFFFFF",
-        padding=SPACE_5,
+        padding=ft.padding.only(
+            left=SPACE_5,
+            right=SPACE_5,
+            top=SPACE_4,
+            bottom=SPACE_4,
+        ),
         border_radius=16,
         alignment=ft.alignment.center,
         shadow=ft.BoxShadow(
@@ -330,6 +334,7 @@ def build_ata_detail_view(
             offset=ft.Offset(0, 5),
         ),
         expand=True,
+        max_width=1152,
     )
 
     return card

--- a/src/ui/navigation_menu.py
+++ b/src/ui/navigation_menu.py
@@ -1,9 +1,9 @@
 import flet as ft
 
 try:
-    from .spacing import SPACE_2, SPACE_3, SPACE_5
+    from .spacing import SPACE_2, SPACE_3, SPACE_4, SPACE_5
 except Exception:  # pragma: no cover
-    from spacing import SPACE_2, SPACE_3, SPACE_5
+    from spacing import SPACE_2, SPACE_3, SPACE_4, SPACE_5
 
 class PopupColorItem(ft.PopupMenuItem):
     def __init__(self, color: str, name: str):
@@ -99,7 +99,12 @@ class LeftNavigationMenu(ft.Column):
         self.rail = NavigationColumn(app, self.destinations)
         self.dark_light_text = ft.Text("Light theme")
         self.dark_light_icon = ft.IconButton(icon=ft.icons.BRIGHTNESS_2_OUTLINED, tooltip="Toggle brightness", on_click=self.theme_changed)
-        self.padding = SPACE_5
+        self.padding = ft.padding.only(
+            left=SPACE_5,
+            right=SPACE_5,
+            top=SPACE_4,
+            bottom=SPACE_4,
+        )
         self.spacing = SPACE_3
         self.controls = [
             self.rail,

--- a/src/ui/responsive.py
+++ b/src/ui/responsive.py
@@ -4,11 +4,16 @@ BREAKPOINT_SM = 640
 BREAKPOINT_MD = 1024
 BREAKPOINT_LG = 1280
 
-# maps breakpoints to paddings and font multipliers
+# maps breakpoints to paddings and font multipliers using design tokens
+try:
+    from .spacing import SPACE_2, SPACE_4, SPACE_5
+except Exception:  # pragma: no cover
+    from spacing import SPACE_2, SPACE_4, SPACE_5
+
 PADDINGS = {
-    "xs": 8,
-    "md": 16,
-    "lg": 24,
+    "xs": SPACE_2,
+    "md": SPACE_4,
+    "lg": SPACE_5,
 }
 
 FONT_SCALE = {
@@ -28,7 +33,7 @@ def get_breakpoint(width: int) -> str:
 
 def get_padding(width: int) -> int:
     bp = get_breakpoint(width)
-    return PADDINGS.get(bp, 16)
+    return PADDINGS.get(bp, SPACE_4)
 
 
 def get_font_size(width: int, base: int) -> int:


### PR DESCRIPTION
## Summary
- remove outer page padding and enforce SPACE_5 gutters on main content
- refactor detail and form dialogs to use token-based padding and responsive max width
- update navigation menu and responsive utilities to eliminate literal spacing values

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68910fb381f08322861844f44e17a27c