### PR TITLE
Fix TypeError from invalid max_width parameter

### DIFF
--- a/src/forms/ata_form.py
+++ b/src/forms/ata_form.py
@@ -250,7 +250,7 @@ class AtaForm:
                 offset=ft.Offset(0, 5),
             ),
             expand=True,
-            max_width=1152,
+            width=1152,
         )
 
         self.dialog = ft.AlertDialog(content=card, modal=True)

--- a/src/ui/ata_detail_view.py
+++ b/src/ui/ata_detail_view.py
@@ -334,7 +334,7 @@ def build_ata_detail_view(
             offset=ft.Offset(0, 5),
         ),
         expand=True,
-        max_width=1152,
+        width=1152,
     )
 
     return card


### PR DESCRIPTION
## Summary
- replace unsupported `max_width` with `width` in Container widgets

## Testing
- `python test_imports.py`

------
https://chatgpt.com/codex/tasks/task_e_68911d8c040c8322b37091d9742a1b48