### PR TITLE
Refactor Atas view spacing and expansion

### DIFF
--- a/src/main_gui.py
+++ b/src/main_gui.py
@@ -143,7 +143,7 @@ class AtaApp:
                 spacing=SPACE_4,
                 run_spacing=SPACE_4,
             ),
-            margin=ft.margin.only(bottom=SPACE_4),
+            margin=ft.margin.only(bottom=0),
             expand=True,
         )
         self.grouped_tables = build_grouped_data_tables(

--- a/src/ui/main_view.py
+++ b/src/ui/main_view.py
@@ -144,8 +144,7 @@ def build_filters(filtro_atual: str, filtro_cb: Callable[[str], None]) -> ft.Con
     )
     return ft.Container(
         content=row,
-        padding=ft.padding.symmetric(horizontal=SPACE_5, vertical=SPACE_4),
-        margin=ft.margin.only(bottom=SPACE_4),
+        padding=ft.padding.symmetric(horizontal=SPACE_5, vertical=SPACE_5),
         expand=True,
     )
 
@@ -446,10 +445,11 @@ def build_grouped_data_tables(
     )
 
     container = ft.Container(
-        content=row,
+        content=ft.Container(content=row, padding=ft.padding.only(bottom=SPACE_5)),
         alignment=ft.alignment.center if filtro == "todos" else ft.alignment.top_left,
-        padding=ft.padding.symmetric(horizontal=SPACE_5),
+        padding=ft.padding.only(left=SPACE_5, right=SPACE_5, top=SPACE_5),
         expand=True,
+        scroll=ft.ScrollMode.AUTO,
     )
     return container
 


### PR DESCRIPTION
## Summary
- adjust filter row padding to 24px top/bottom
- extend Atas cards container with top/bottom spacing and auto scroll
- remove extra margin between filter/search row and cards block

## Testing
- `python test_imports.py`


------
https://chatgpt.com/codex/tasks/task_e_68912abd0bb883228adde8c1badaaef1