### PR TITLE
Refatorar disposição de grupos de atas

### DIFF
--- a/src/ui/main_view.py
+++ b/src/ui/main_view.py
@@ -410,12 +410,7 @@ def build_grouped_data_tables(
         )
 
         card = build_card(info["title"], icon, table)
-
-        if filtro == "todos":
-            card.col = {"xs": 12, "lg": 4}
-        else:
-            # Single card should span the entire content area
-            card.col = 12
+        card.col = 12
         card.expand = True
         card_controls.append(card)
 
@@ -431,18 +426,21 @@ def build_grouped_data_tables(
             expand=True,
         )
 
-    row = ft.ResponsiveRow(
-        card_controls,
-        columns=12,
-        alignment=ft.MainAxisAlignment.START,
-        spacing=SPACE_5,
-        run_spacing=SPACE_5,
-        expand=True,
-    )
+    if filtro == "todos":
+        layout = ft.Column(card_controls, spacing=SPACE_5, expand=True)
+    else:
+        layout = ft.ResponsiveRow(
+            card_controls,
+            columns=12,
+            alignment=ft.MainAxisAlignment.START,
+            spacing=SPACE_5,
+            run_spacing=SPACE_5,
+            expand=True,
+        )
 
     container = ft.Container(
         content=ft.Column(
-            [row],
+            [layout],
             scroll=ft.ScrollMode.AUTO,
             expand=True,
         ),


### PR DESCRIPTION
## Summary
- Exibir todas as atas agora organiza os grupos em coluna, com espaçamento vertical consistente
- Padronizado o tamanho dos cards e mantidos os gutters laterais

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689218101ca88322b348da7e229e695f