### PR TITLE
Refatora layout das atas para exibição vertical no filtro "Todas"

### DIFF
--- a/src/ui/main_view.py
+++ b/src/ui/main_view.py
@@ -371,8 +371,8 @@ def build_grouped_data_tables(
 
     When ``filtro`` is one of ``vigente``, ``a_vencer`` or ``vencida``, only the
     corresponding card is returned and it expands to occupy the full available
-    width.  When ``filtro`` is ``todos`` the original layout with three cards is
-    rendered.
+    width.  When ``filtro`` is ``todos`` the cards are stacked vertically,
+    occupying the full width of the container.
     """
 
     groups: dict[str, list[Ata]] = {key: [] for key in STATUS_INFO}
@@ -410,12 +410,6 @@ def build_grouped_data_tables(
         )
 
         card = build_card(info["title"], icon, table)
-
-        if filtro == "todos":
-            card.col = {"xs": 12, "lg": 4}
-        else:
-            # Single card should span the entire content area
-            card.col = 12
         card.expand = True
         card_controls.append(card)
 
@@ -431,21 +425,18 @@ def build_grouped_data_tables(
             expand=True,
         )
 
-    row = ft.ResponsiveRow(
-        card_controls,
-        columns=12,
-        alignment=ft.MainAxisAlignment.START,
-        spacing=SPACE_5,
-        run_spacing=SPACE_5,
-        expand=True,
-    )
+    if filtro == "todos":
+        content = ft.Column(
+            card_controls,
+            spacing=SPACE_5,
+            scroll=ft.ScrollMode.HIDDEN,
+            expand=True,
+        )
+    else:
+        content = ft.Column(card_controls, expand=True)
 
     container = ft.Container(
-        content=ft.Column(
-            [row],
-            scroll=ft.ScrollMode.AUTO,
-            expand=True,
-        ),
+        content=content,
         alignment=ft.alignment.top_left,
         padding=ft.padding.only(left=SPACE_5, right=SPACE_5, top=SPACE_5, bottom=SPACE_5),
         expand=True,


### PR DESCRIPTION
## Summary
- reorganize grouped data tables to stack status cards vertically when "Todas" filter is active
- remove responsive row and ensure cards use full width with proper spacing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68921e6a97c083229d4dedb2eb321ac6