### PR TITLE
fix: replace invalid relative imports

### DIFF
--- a/src/components/appbar.py
+++ b/src/components/appbar.py
@@ -1,6 +1,6 @@
 """Top AppBar component."""
 import flet as ft
-from ..constants import SPACE_4
+from constants import SPACE_4
 
 
 def create_appbar(app) -> ft.AppBar:

--- a/src/components/sidebar.py
+++ b/src/components/sidebar.py
@@ -1,6 +1,6 @@
 """Sidebar component with navigation and theme controls."""
 import flet as ft
-from ..constants import SPACE_3, SPACE_4, SPACE_5
+from constants import SPACE_3, SPACE_4, SPACE_5
 
 
 def create_sidebar(app) -> ft.Container:

--- a/src/views/atas_view.py
+++ b/src/views/atas_view.py
@@ -1,6 +1,6 @@
 """Main Atas view with filters and tables."""
 import flet as ft
-from ..constants import SPACE_4, SPACE_5
+from constants import SPACE_4, SPACE_5
 from widgets.badges import status_badge
 
 SAMPLE_ATAS = [

--- a/src/views/dashboard.py
+++ b/src/views/dashboard.py
@@ -1,6 +1,6 @@
 """Dashboard view."""
 import flet as ft
-from ..constants import SPACE_4, SPACE_5
+from constants import SPACE_4, SPACE_5
 
 
 def create_dashboard(app) -> ft.Column:

--- a/src/views/vencimentos_view.py
+++ b/src/views/vencimentos_view.py
@@ -1,6 +1,6 @@
 """View listing Atas close to expiration."""
 import flet as ft
-from ..constants import SPACE_4
+from constants import SPACE_4
 
 SAMPLE_VENCIMENTOS = [
     {"numero": "001/2024", "fornecedor": "Tech Ltda", "dias": 20},

--- a/src/widgets/ata_form.py
+++ b/src/widgets/ata_form.py
@@ -1,6 +1,6 @@
 """Form dialog for creating or editing an Ata."""
 import flet as ft
-from ..constants import SPACE_3, SPACE_4
+from constants import SPACE_3, SPACE_4
 
 
 def create_ata_form(on_cancel, on_save) -> ft.AlertDialog:

--- a/src/widgets/badges.py
+++ b/src/widgets/badges.py
@@ -1,6 +1,6 @@
 """Badge and indicator widgets."""
 from flet import colors, Container, padding, Text
-from ..constants import SPACE_1, SPACE_3
+from constants import SPACE_1, SPACE_3
 
 
 def status_badge(status: str) -> Container:

--- a/src/widgets/details_card.py
+++ b/src/widgets/details_card.py
@@ -1,6 +1,6 @@
 """Detailed card for displaying Ata information."""
 import flet as ft
-from ..constants import SPACE_3, SPACE_4, SPACE_5
+from constants import SPACE_3, SPACE_4, SPACE_5
 from .badges import status_badge
 
 


### PR DESCRIPTION
## Summary
- use absolute imports for constants in UI modules

## Testing
- `python3 test_imports.py`


------
https://chatgpt.com/codex/tasks/task_e_689250a93194832288b07c2ffe13055f