### PR TITLE
Fix LineChart initialization for new Flet API

### DIFF
--- a/src/views/dashboard.py
+++ b/src/views/dashboard.py
@@ -40,9 +40,9 @@ def create_dashboard(app) -> ft.Column:
     )
 
     line = ft.LineChart(
-        lines=[
+        data_series=[
             ft.LineChartData(
-                data=[
+                data_points=[
                     ft.LineChartDataPoint(1, 10),
                     ft.LineChartDataPoint(2, 20),
                     ft.LineChartDataPoint(3, 40),


### PR DESCRIPTION
## Summary
- align LineChart usage with updated Flet API by switching to `data_series` and `data_points`

## Testing
- `python test_imports.py`


------
https://chatgpt.com/codex/tasks/task_e_6892523429fc83228740ac29365ade4c