### PR TITLE
Implement themed color palette for app

### DIFF
--- a/src/main_gui.py
+++ b/src/main_gui.py
@@ -21,6 +21,7 @@ from ui.main_view import (
 from ui.navigation_menu import LeftNavigationMenu
 from ui import build_ata_detail_view
 from ui.theme.spacing import SPACE_2, SPACE_4, SPACE_5
+from ui.theme import colors as theme_colors
 from ui.responsive import get_breakpoint
 
 class AtaApp:
@@ -48,7 +49,8 @@ class AtaApp:
         self.page.theme_mode = ft.ThemeMode.LIGHT
         # Remove outer page padding to ensure consistent gutter handled by body container
         self.page.padding = 0
-        self.page.bgcolor = "#F3F4F6"
+        # Apply initial theme colors
+        self.apply_theme()
         self.page.fonts = {"Inter": "https://fonts.gstatic.com/s/inter/v7/Inter-Regular.ttf"}
         self.page.theme = ft.Theme(font_family="Inter")
         self.page.on_resize = self.on_page_resize
@@ -56,6 +58,7 @@ class AtaApp:
     def build_ui(self):
         """Constrói a interface do usuário usando navegação lateral"""
         self.page.appbar = build_header(
+            self.page,
             nova_ata_cb=self.nova_ata_click,
             verificar_alertas_cb=self.verificar_alertas_manual,
             relatorio_semanal_cb=lambda e: self.gerar_relatorio_manual("semanal"),
@@ -71,10 +74,11 @@ class AtaApp:
         )
         self.update_body()
 
+        scheme = theme_colors.scheme(self.page)
         self.menu_container = ft.Container(
             content=self.navigation_menu,
             width=200,
-            bgcolor=ft.colors.WHITE,
+            bgcolor=scheme["sidebar_bg"],
             padding=ft.padding.only(
                 left=SPACE_5,
                 right=SPACE_5,
@@ -109,6 +113,22 @@ class AtaApp:
             self.menu_container.padding = ft.padding.all(SPACE_5)
 
         self.page.update()
+
+    def apply_theme(self):
+        """Atualiza cores baseadas no tema atual."""
+        scheme = theme_colors.scheme(self.page)
+        self.page.bgcolor = scheme["app_bg"]
+        if hasattr(self, "menu_container"):
+            self.menu_container.bgcolor = scheme["sidebar_bg"]
+        if hasattr(self, "navigation_menu"):
+            self.navigation_menu.refresh_theme()
+        if self.page.appbar:
+            self.page.appbar.bgcolor = scheme["header_bg"]
+            if isinstance(self.page.appbar.title, ft.Text):
+                self.page.appbar.title.color = scheme["header_title"]
+            if isinstance(self.page.appbar.leading, ft.Icon):
+                self.page.appbar.leading.color = scheme["sidebar_title"]
+        self.page.update()
     
     def build_stats_panel(self):
         """Retorna o painel de estatísticas"""
@@ -130,7 +150,7 @@ class AtaApp:
     def build_atas_view(self):
         filtros = build_filters(self.filtro_atual, self.filtrar_atas)
         search_container, self.search_field = build_search(
-            self.buscar_atas, self.texto_busca
+            self.buscar_atas, self.texto_busca, self.page
         )
         filtros.margin = ft.margin.only(bottom=0)
         search_container.margin = ft.margin.only(bottom=0)

--- a/src/ui/main_view.py
+++ b/src/ui/main_view.py
@@ -10,7 +10,8 @@ try:
         SPACE_5,
         SPACE_6,
     )
-    from .tokens import build_card, primary_button
+    from .tokens import build_card
+    from .theme import colors as theme_colors
 except Exception:  # pragma: no cover - fallback for standalone execution
     from theme.spacing import (
         SPACE_1,
@@ -20,7 +21,8 @@ except Exception:  # pragma: no cover - fallback for standalone execution
         SPACE_5,
         SPACE_6,
     )
-    from tokens import build_card, primary_button
+    from tokens import build_card
+    from theme import colors as theme_colors
 
 try:
     from ..models.ata import Ata
@@ -61,6 +63,7 @@ STATUS_INFO = {
 
 
 def build_header(
+    page: ft.Page,
     nova_ata_cb: Callable,
     verificar_alertas_cb: Callable,
     relatorio_semanal_cb: Callable,
@@ -69,6 +72,22 @@ def build_header(
     status_cb: Callable,
 ) -> ft.AppBar:
     """Return AppBar with menu actions and new ata button."""
+    scheme = theme_colors.scheme(page)
+
+    new_btn = ft.FilledButton(
+        text="Nova Ata",
+        icon=ft.icons.ADD,
+        on_click=nova_ata_cb,
+        style=ft.ButtonStyle(
+            bgcolor={
+                ft.MaterialState.DEFAULT: scheme["new_button_bg"],
+                ft.MaterialState.HOVERED: scheme["new_button_hover"],
+            },
+            color={ft.MaterialState.DEFAULT: scheme["new_button_text"]},
+            shape=ft.RoundedRectangleBorder(radius=8),
+        ),
+    )
+
     actions_row = ft.Row(
         [
             ft.PopupMenuButton(
@@ -82,21 +101,17 @@ def build_header(
                     ft.PopupMenuItem(text="ℹ️ Status Sistema", on_click=status_cb),
                 ],
             ),
-            primary_button(
-                "Nova Ata",
-                icon=ft.icons.ADD,
-                on_click=nova_ata_cb,
-            ),
+            new_btn,
         ],
         spacing=SPACE_4,
         vertical_alignment=ft.CrossAxisAlignment.CENTER,
     )
 
     return ft.AppBar(
-        leading=ft.Icon(ft.icons.DESCRIPTION_OUTLINED),
+        leading=ft.Icon(ft.icons.DESCRIPTION_OUTLINED, color=scheme["sidebar_title"]),
         leading_width=40,
-        title=ft.Text("Ata de Registro de Preços"),
-        bgcolor=ft.colors.INVERSE_PRIMARY,
+        title=ft.Text("Ata de Registro de Preços", color=scheme["header_title"]),
+        bgcolor=scheme["header_bg"],
         actions=[
             ft.Container(
                 content=actions_row,
@@ -149,8 +164,10 @@ def build_filters(filtro_atual: str, filtro_cb: Callable[[str], None]) -> ft.Con
     )
 
 
-def build_search(on_change: Callable, value: str = "") -> tuple[ft.Container, ft.TextField]:
+def build_search(on_change: Callable, value: str = "", page: ft.Page | None = None) -> tuple[ft.Container, ft.TextField]:
     """Return a search container and field pre-populated with ``value``."""
+    page = page or ft.Page()
+    scheme = theme_colors.scheme(page)
     search_field = ft.TextField(
         hint_text="Buscar atas...",
         prefix_icon=ft.icons.SEARCH,
@@ -159,16 +176,16 @@ def build_search(on_change: Callable, value: str = "") -> tuple[ft.Container, ft
         expand=True,
         height=40,
         text_style=ft.TextStyle(
-            size=14, weight=ft.FontWeight.W_500, color=ft.colors.GREY_900
+            size=14, weight=ft.FontWeight.W_500, color=scheme["app_text"]
         ),
         hint_style=ft.TextStyle(
-            size=14, weight=ft.FontWeight.W_500, color=ft.colors.GREY_900
+            size=14, weight=ft.FontWeight.W_500, color=scheme["app_text"]
         ),
         border_radius=8,
-        border_color=ft.colors.GREY_300,
-        focused_border_color="#3B82F6",
-        bgcolor=ft.colors.WHITE,
-        hover_color=ft.colors.with_opacity(0.08, ft.colors.BLACK),
+        border_color=scheme["tabs_border"],
+        focused_border_color=scheme["search_focus_border"],
+        bgcolor=scheme["search_bg"],
+        prefix_icon_color=scheme["search_icon"],
         content_padding=ft.padding.symmetric(horizontal=SPACE_4, vertical=0),
     )
     return (

--- a/src/ui/theme/colors.py
+++ b/src/ui/theme/colors.py
@@ -1,0 +1,119 @@
+import flet as ft
+
+# Color schemes for light and dark modes
+LIGHT = {
+    # Application
+    "app_bg": ft.colors.GREY_100,
+    "app_text": ft.colors.GREY_900,
+    # Sidebar
+    "sidebar_bg": ft.colors.WHITE,
+    "sidebar_title": ft.colors.INDIGO_500,
+    "nav_link": ft.colors.GREY_700,
+    "nav_link_hover_bg": ft.colors.INDIGO_100,
+    "nav_link_hover_text": ft.colors.INDIGO_600,
+    "nav_link_active_bg": ft.colors.INDIGO_50,
+    "nav_link_active_text": ft.colors.INDIGO_600,
+    "toggle_bg": ft.colors.GREY_100,
+    "toggle_sun": ft.colors.AMBER_400,
+    "toggle_moon": ft.colors.GREY_500,
+    # Header
+    "header_bg": ft.colors.WHITE,
+    "header_title": ft.colors.GREY_900,
+    "search_bg": ft.colors.GREY_100,
+    "search_icon": ft.colors.GREY_400,
+    "search_focus_border": ft.colors.INDIGO_500,
+    "new_button_bg": ft.colors.INDIGO_600,
+    "new_button_text": ft.colors.WHITE,
+    "new_button_hover": ft.colors.INDIGO_700,
+    # Tabs
+    "tabs_border": ft.colors.GREY_200,
+    "tab_text": ft.colors.GREY_500,
+    "tab_text_hover": ft.colors.GREY_700,
+    "tab_active_border": ft.colors.INDIGO_500,
+    "tab_active_text": ft.colors.INDIGO_600,
+    # Tables
+    "table_bg": ft.colors.WHITE,
+    "table_title": ft.colors.GREY_900,
+    "table_header_border": ft.colors.GREY_200,
+    "table_header_bg": ft.colors.GREY_50,
+    "table_header_text": ft.colors.GREY_500,
+    "table_number": ft.colors.GREY_900,
+    "table_text": ft.colors.GREY_500,
+    "table_divider": ft.colors.GREY_200,
+    "table_no_records": ft.colors.GREY_500,
+    # Badges
+    "badge_vigente_bg": ft.colors.GREEN_100,
+    "badge_vigente_text": ft.colors.GREEN_800,
+    "badge_avencer_bg": ft.colors.YELLOW_100,
+    "badge_avencer_text": ft.colors.YELLOW_800,
+    "badge_vencida_bg": ft.colors.RED_100,
+    "badge_vencida_text": ft.colors.RED_800,
+    # Action buttons
+    "action_ver": ft.colors.INDIGO_600,
+    "action_ver_hover": ft.colors.INDIGO_900,
+    "action_editar": ft.colors.GREY_600,
+    "action_editar_hover": ft.colors.GREY_900,
+    "action_excluir": ft.colors.RED_600,
+    "action_excluir_hover": ft.colors.RED_900,
+}
+
+DARK = {
+    # Application
+    "app_bg": ft.colors.GREY_900,
+    "app_text": ft.colors.WHITE,
+    # Sidebar
+    "sidebar_bg": ft.colors.GREY_800,
+    "sidebar_title": ft.colors.INDIGO_500,
+    "nav_link": ft.colors.GREY_300,
+    "nav_link_hover_bg": ft.colors.INDIGO_900,
+    "nav_link_hover_text": ft.colors.INDIGO_300,
+    "nav_link_active_bg": ft.colors.INDIGO_900,
+    "nav_link_active_text": ft.colors.INDIGO_300,
+    "toggle_bg": ft.colors.GREY_700,
+    "toggle_sun": ft.colors.AMBER_400,
+    "toggle_moon": ft.colors.GREY_500,
+    # Header
+    "header_bg": ft.colors.GREY_800,
+    "header_title": ft.colors.WHITE,
+    "search_bg": ft.colors.GREY_700,
+    "search_icon": ft.colors.GREY_400,
+    "search_focus_border": ft.colors.INDIGO_500,
+    "new_button_bg": ft.colors.INDIGO_600,
+    "new_button_text": ft.colors.WHITE,
+    "new_button_hover": ft.colors.INDIGO_700,
+    # Tabs
+    "tabs_border": ft.colors.GREY_700,
+    "tab_text": ft.colors.GREY_400,
+    "tab_text_hover": ft.colors.GREY_200,
+    "tab_active_border": ft.colors.INDIGO_500,
+    "tab_active_text": ft.colors.INDIGO_400,
+    # Tables
+    "table_bg": ft.colors.GREY_800,
+    "table_title": ft.colors.WHITE,
+    "table_header_border": ft.colors.GREY_700,
+    "table_header_bg": ft.colors.GREY_700,
+    "table_header_text": ft.colors.GREY_300,
+    "table_number": ft.colors.WHITE,
+    "table_text": ft.colors.GREY_400,
+    "table_divider": ft.colors.GREY_700,
+    "table_no_records": ft.colors.GREY_400,
+    # Badges
+    "badge_vigente_bg": ft.colors.GREEN_900,
+    "badge_vigente_text": ft.colors.GREEN_300,
+    "badge_avencer_bg": ft.colors.YELLOW_900,
+    "badge_avencer_text": ft.colors.YELLOW_300,
+    "badge_vencida_bg": ft.colors.RED_900,
+    "badge_vencida_text": ft.colors.RED_300,
+    # Action buttons
+    "action_ver": ft.colors.INDIGO_400,
+    "action_ver_hover": ft.colors.INDIGO_300,
+    "action_editar": ft.colors.GREY_400,
+    "action_editar_hover": ft.colors.GREY_300,
+    "action_excluir": ft.colors.RED_400,
+    "action_excluir_hover": ft.colors.RED_300,
+}
+
+
+def scheme(page: ft.Page) -> dict:
+    """Return color scheme based on current page theme mode."""
+    return DARK if page.theme_mode == ft.ThemeMode.DARK else LIGHT


### PR DESCRIPTION
## Summary
- add centralized color palette supporting light and dark modes
- apply theme colors to navigation menu, header and search field
- update app to refresh colors on theme toggle

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68925532eb14832289710580662c0b9f