### PR TITLE
Add reusable BoxShadow presets for UI components

### DIFF
--- a/src/forms/ata_form.py
+++ b/src/forms/ata_form.py
@@ -11,6 +11,7 @@ try:
         SPACE_5,
         SPACE_6,
     )
+    from ..ui.theme.shadows import SHADOW_LG
     from ..ui.tokens import build_section, primary_button, secondary_button
 except Exception:  # pragma: no cover
     from ui.theme.spacing import (
@@ -21,6 +22,7 @@ except Exception:  # pragma: no cover
         SPACE_5,
         SPACE_6,
     )
+    from ui.theme.shadows import SHADOW_LG
     from ui.tokens import build_section, primary_button, secondary_button
 try:
     from ..models.ata import Ata, Item
@@ -248,12 +250,7 @@ class AtaForm:
             ),
             border_radius=8,
             alignment=ft.alignment.center,
-            shadow=ft.BoxShadow(
-                spread_radius=1,
-                blur_radius=15,
-                color=ft.colors.with_opacity(0.1, ft.colors.BLACK),
-                offset=ft.Offset(0, 5),
-            ),
+            shadow=SHADOW_LG,
             expand=True,
             width=1152,
         )

--- a/src/main_gui.py
+++ b/src/main_gui.py
@@ -21,6 +21,7 @@ from ui.main_view import (
 from ui.navigation_menu import LeftNavigationMenu
 from ui import build_ata_detail_view
 from ui.theme.spacing import SPACE_2, SPACE_4, SPACE_5
+from ui.theme.shadows import SHADOW_XL
 from ui.responsive import get_breakpoint
 
 class AtaApp:
@@ -81,7 +82,7 @@ class AtaApp:
                 top=SPACE_5,
                 bottom=SPACE_5,
             ),
-            shadow=ft.BoxShadow(blur_radius=1, spread_radius=0),
+            shadow=SHADOW_XL,
         )
 
         layout = ft.Row(

--- a/src/ui/ata_detail_view.py
+++ b/src/ui/ata_detail_view.py
@@ -11,6 +11,7 @@ try:
         SPACE_5,
         SPACE_6,
     )
+    from .theme.shadows import SHADOW_LG
     from .tokens import build_section, primary_button, secondary_button
 except Exception:  # pragma: no cover
     from theme.spacing import (
@@ -21,6 +22,7 @@ except Exception:  # pragma: no cover
         SPACE_5,
         SPACE_6,
     )
+    from theme.shadows import SHADOW_LG
     from tokens import build_section, primary_button, secondary_button
 
 try:
@@ -327,12 +329,7 @@ def build_ata_detail_view(
         ),
         border_radius=8,
         alignment=ft.alignment.center,
-        shadow=ft.BoxShadow(
-            spread_radius=1,
-            blur_radius=15,
-            color=ft.colors.with_opacity(0.1, ft.colors.BLACK),
-            offset=ft.Offset(0, 5),
-        ),
+        shadow=SHADOW_LG,
         expand=True,
         width=1152,
     )

--- a/src/ui/theme/__init__.py
+++ b/src/ui/theme/__init__.py
@@ -1,3 +1,3 @@
-from . import spacing
+from . import spacing, shadows
 
-__all__ = ["spacing"]
+__all__ = ["spacing", "shadows"]

--- a/src/ui/theme/shadows.py
+++ b/src/ui/theme/shadows.py
@@ -1,0 +1,25 @@
+import flet as ft
+
+SHADOW_XL = ft.BoxShadow(
+    blur_radius=25,
+    offset=ft.Offset(0, 20),
+    color=ft.colors.BLACK12,
+)
+
+SHADOW_LG = ft.BoxShadow(
+    blur_radius=15,
+    offset=ft.Offset(0, 10),
+    color=ft.colors.BLACK12,
+)
+
+SHADOW_MD = ft.BoxShadow(
+    blur_radius=6,
+    offset=ft.Offset(0, 4),
+    color=ft.colors.BLACK12,
+)
+
+__all__ = [
+    "SHADOW_XL",
+    "SHADOW_LG",
+    "SHADOW_MD",
+]

--- a/src/ui/tokens.py
+++ b/src/ui/tokens.py
@@ -6,6 +6,7 @@ from .theme.spacing import (
     SPACE_5,
     SPACE_6,
 )
+from .theme.shadows import SHADOW_MD
 
 import flet as ft
 from typing import Callable, Optional
@@ -105,10 +106,5 @@ def build_card(title: str, icon: ft.Control, content: ft.Control) -> ft.Control:
         border=ft.border.all(1, GREY_LIGHT),
         border_radius=8,
         bgcolor=ft.colors.WHITE,
-        shadow=ft.BoxShadow(
-            spread_radius=0,
-            blur_radius=6,
-            color=ft.colors.with_opacity(0.1, ft.colors.BLACK),
-            offset=ft.Offset(0, 2),
-        ),
+        shadow=SHADOW_MD,
     )


### PR DESCRIPTION
## Summary
- add theme/shadows module with standard BoxShadow presets
- apply shadow tokens across sidebar, cards, and detail views

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68925653c76083229971da489a3431d8