### PR TITLE
refactor: add theme color palette

### DIFF
--- a/src/main_gui.py
+++ b/src/main_gui.py
@@ -22,6 +22,7 @@ from ui.navigation_menu import LeftNavigationMenu
 from ui import build_ata_detail_view
 from ui.theme.spacing import SPACE_2, SPACE_4, SPACE_5
 from ui.theme.shadows import SHADOW_XL
+from ui.theme.colors import get_theme
 from ui.responsive import get_breakpoint
 
 class AtaApp:
@@ -49,13 +50,16 @@ class AtaApp:
         self.page.theme_mode = ft.ThemeMode.LIGHT
         # Remove outer page padding to ensure consistent gutter handled by body container
         self.page.padding = 0
-        self.page.bgcolor = "#F3F4F6"
+        theme = get_theme(self.page.theme_mode)
+        self.page.bgcolor = theme["app_bg"]
         self.page.fonts = {"Inter": "https://fonts.gstatic.com/s/inter/v7/Inter-Regular.ttf"}
         self.page.theme = ft.Theme(font_family="Inter")
         self.page.on_resize = self.on_page_resize
     
     def build_ui(self):
         """Constrói a interface do usuário usando navegação lateral"""
+        theme = get_theme(self.page.theme_mode)
+
         self.page.appbar = build_header(
             nova_ata_cb=self.nova_ata_click,
             verificar_alertas_cb=self.verificar_alertas_manual,
@@ -63,9 +67,11 @@ class AtaApp:
             relatorio_mensal_cb=lambda e: self.gerar_relatorio_manual("mensal"),
             testar_email_cb=self.testar_email,
             status_cb=self.mostrar_status_sistema,
+            theme=theme,
         )
+        self.page.bgcolor = theme["app_bg"]
 
-        self.navigation_menu = LeftNavigationMenu(self)
+        self.navigation_menu = LeftNavigationMenu(self, theme)
         self.body_container = ft.Container(
             padding=ft.padding.only(top=SPACE_4, bottom=SPACE_4),
             expand=True,
@@ -75,7 +81,7 @@ class AtaApp:
         self.menu_container = ft.Container(
             content=self.navigation_menu,
             width=200,
-            bgcolor=ft.colors.WHITE,
+            bgcolor=theme["sidebar"]["bg"],
             padding=ft.padding.only(
                 left=SPACE_5,
                 right=SPACE_5,
@@ -110,6 +116,11 @@ class AtaApp:
             self.menu_container.padding = ft.padding.all(SPACE_5)
 
         self.page.update()
+
+    def apply_theme(self):
+        """Rebuild UI applying current theme colors."""
+        self.page.controls.clear()
+        self.build_ui()
     
     def build_stats_panel(self):
         """Retorna o painel de estatísticas"""
@@ -129,9 +140,10 @@ class AtaApp:
         return ft.Column([self.stats_container], spacing=0, expand=True)
 
     def build_atas_view(self):
+        theme = get_theme(self.page.theme_mode)
         filtros = build_filters(self.filtro_atual, self.filtrar_atas)
         search_container, self.search_field = build_search(
-            self.buscar_atas, self.texto_busca
+            self.buscar_atas, self.texto_busca, theme=theme
         )
         filtros.margin = ft.margin.only(bottom=0)
         search_container.margin = ft.margin.only(bottom=0)
@@ -153,6 +165,7 @@ class AtaApp:
             self.editar_ata,
             self.excluir_ata,
             filtro=self.filtro_atual,
+            theme=theme,
         )
         return ft.Column([filtros_search_row, self.grouped_tables], spacing=0, expand=True)
 

--- a/src/ui/main_view.py
+++ b/src/ui/main_view.py
@@ -10,7 +10,7 @@ try:
         SPACE_5,
         SPACE_6,
     )
-    from .tokens import build_card, primary_button
+    from .tokens import build_card
 except Exception:  # pragma: no cover - fallback for standalone execution
     from theme.spacing import (
         SPACE_1,
@@ -20,7 +20,7 @@ except Exception:  # pragma: no cover - fallback for standalone execution
         SPACE_5,
         SPACE_6,
     )
-    from tokens import build_card, primary_button
+    from tokens import build_card
 
 try:
     from ..models.ata import Ata
@@ -67,6 +67,7 @@ def build_header(
     relatorio_mensal_cb: Callable,
     testar_email_cb: Callable,
     status_cb: Callable,
+    theme: dict,
 ) -> ft.AppBar:
     """Return AppBar with menu actions and new ata button."""
     actions_row = ft.Row(
@@ -82,10 +83,18 @@ def build_header(
                     ft.PopupMenuItem(text="ℹ️ Status Sistema", on_click=status_cb),
                 ],
             ),
-            primary_button(
+            ft.ElevatedButton(
                 "Nova Ata",
                 icon=ft.icons.ADD,
                 on_click=nova_ata_cb,
+                style=ft.ButtonStyle(
+                    bgcolor={
+                        "": theme["header"]["button_bg"],
+                        ft.MaterialState.HOVERED: theme["header"]["button_hover_bg"],
+                    },
+                    color=theme["header"]["button_text"],
+                    shape=ft.RoundedRectangleBorder(radius=9999),
+                ),
             ),
         ],
         spacing=SPACE_4,
@@ -93,10 +102,10 @@ def build_header(
     )
 
     return ft.AppBar(
-        leading=ft.Icon(ft.icons.DESCRIPTION_OUTLINED),
+        leading=ft.Icon(ft.icons.DESCRIPTION_OUTLINED, color=theme["header"]["title"]),
         leading_width=40,
-        title=ft.Text("Ata de Registro de Preços"),
-        bgcolor=ft.colors.INVERSE_PRIMARY,
+        title=ft.Text("Ata de Registro de Preços", color=theme["header"]["title"]),
+        bgcolor=theme["header"]["bg"],
         actions=[
             ft.Container(
                 content=actions_row,
@@ -149,25 +158,31 @@ def build_filters(filtro_atual: str, filtro_cb: Callable[[str], None]) -> ft.Con
     )
 
 
-def build_search(on_change: Callable, value: str = "") -> tuple[ft.Container, ft.TextField]:
+def build_search(on_change: Callable, value: str = "", theme: dict = None) -> tuple[ft.Container, ft.TextField]:
     """Return a search container and field pre-populated with ``value``."""
+    theme = theme or {}
     search_field = ft.TextField(
         hint_text="Buscar atas...",
         prefix_icon=ft.icons.SEARCH,
+        prefix_icon_color=theme.get("header", {}).get("search_icon"),
         on_change=on_change,
         value=value,
         expand=True,
         height=40,
         text_style=ft.TextStyle(
-            size=14, weight=ft.FontWeight.W_500, color=ft.colors.GREY_900
+            size=14,
+            weight=ft.FontWeight.W_500,
+            color=theme.get("header", {}).get("search_text"),
         ),
         hint_style=ft.TextStyle(
-            size=14, weight=ft.FontWeight.W_500, color=ft.colors.GREY_900
+            size=14,
+            weight=ft.FontWeight.W_500,
+            color=theme.get("header", {}).get("search_placeholder"),
         ),
         border_radius=9999,
         border_color=ft.colors.GREY_300,
-        focused_border_color="#3B82F6",
-        bgcolor=ft.colors.WHITE,
+        focused_border_color=theme.get("header", {}).get("search_focus"),
+        bgcolor=theme.get("header", {}).get("search_bg"),
         hover_color=ft.colors.with_opacity(0.08, ft.colors.BLACK),
         content_padding=ft.padding.symmetric(horizontal=SPACE_4, vertical=0),
     )
@@ -189,13 +204,14 @@ def build_data_table(
     editar_cb: Callable[[Ata], None],
     excluir_cb: Callable[[Ata], None],
     status: str,
+    theme: dict,
 ) -> ft.Column:
     """Return custom table for a list of atas respecting design specs."""
     if not atas:
         return ft.Container(
             content=ft.Text(
                 "Nenhuma ata encontrada",
-                color="#6B7280",
+                color=theme["table"]["no_record"],
                 no_wrap=True,
             ),
             alignment=ft.alignment.center,
@@ -213,7 +229,7 @@ def build_data_table(
                 lbl.upper(),
                 size=11,
                 weight=ft.FontWeight.W_600,
-                color="#6B7280",
+                color=theme["table"]["header_text"],
                 no_wrap=True,
                 text_align=ft.TextAlign.CENTER,
             ),
@@ -231,14 +247,23 @@ def build_data_table(
         ),
         alignment=ft.alignment.center,
         padding=ft.padding.symmetric(vertical=SPACE_4, horizontal=SPACE_4),
-        bgcolor="#F9FAFB",
-        border=ft.border.only(bottom=ft.BorderSide(1, "#E5E7EB")),
+        bgcolor=theme["table"]["header_bg"],
+        border=ft.border.only(bottom=ft.BorderSide(1, theme["table"]["header_border"])),
     )
 
     badge_colors = {
-        "vigente": ("#14532D", "#D1FAE5"),
-        "a_vencer": ("#713F12", "#FEF9C3"),
-        "vencida": ("#991B1B", "#FEE2E2"),
+        "vigente": (
+            theme["badges"]["vigente_text"],
+            theme["badges"]["vigente_bg"],
+        ),
+        "a_vencer": (
+            theme["badges"]["a_vencer_text"],
+            theme["badges"]["a_vencer_bg"],
+        ),
+        "vencida": (
+            theme["badges"]["vencida_text"],
+            theme["badges"]["vencida_bg"],
+        ),
     }
 
     rows: list[ft.Control] = []
@@ -249,7 +274,7 @@ def build_data_table(
             ft.Text(
                 ata.numero_ata,
                 weight=ft.FontWeight.W_500,
-                color="#111827",
+                color=theme["table"]["number_text"],
                 max_lines=1,
                 no_wrap=True,
                 overflow=ft.TextOverflow.ELLIPSIS,
@@ -261,6 +286,7 @@ def build_data_table(
                 no_wrap=True,
                 overflow=ft.TextOverflow.ELLIPSIS,
                 text_align=ft.TextAlign.CENTER,
+                color=theme["table"]["other_text"],
             ),
             ft.Text(
                 ata.objeto,
@@ -268,6 +294,7 @@ def build_data_table(
                 no_wrap=True,
                 overflow=ft.TextOverflow.ELLIPSIS,
                 text_align=ft.TextAlign.CENTER,
+                color=theme["table"]["other_text"],
             ),
             ft.Text(
                 ata.fornecedor,
@@ -275,6 +302,7 @@ def build_data_table(
                 no_wrap=True,
                 overflow=ft.TextOverflow.ELLIPSIS,
                 text_align=ft.TextAlign.CENTER,
+                color=theme["table"]["other_text"],
             ),
         ]
         badge_text_color, badge_bg_color = badge_colors[ata.status]
@@ -300,7 +328,10 @@ def build_data_table(
                     tooltip="Visualizar",
                     on_click=lambda e, ata=ata: visualizar_cb(ata),
                     style=ft.ButtonStyle(
-                        color={ft.MaterialState.HOVERED: "#2563EB", "": "#6B7280"}
+                        color={
+                            ft.MaterialState.HOVERED: theme["actions"]["view_hover"],
+                            "": theme["actions"]["view"],
+                        }
                     ),
                     icon_size=20,
                 ),
@@ -309,7 +340,10 @@ def build_data_table(
                     tooltip="Editar",
                     on_click=lambda e, ata=ata: editar_cb(ata),
                     style=ft.ButtonStyle(
-                        color={ft.MaterialState.HOVERED: "#CA8A04", "": "#6B7280"}
+                        color={
+                            ft.MaterialState.HOVERED: theme["actions"]["edit_hover"],
+                            "": theme["actions"]["edit"],
+                        }
                     ),
                     icon_size=20,
                 ),
@@ -318,7 +352,10 @@ def build_data_table(
                     tooltip="Excluir",
                     on_click=lambda e, ata=ata: excluir_cb(ata),
                     style=ft.ButtonStyle(
-                        color={ft.MaterialState.HOVERED: "#DC2626", "": "#6B7280"}
+                        color={
+                            ft.MaterialState.HOVERED: theme["actions"]["delete_hover"],
+                            "": theme["actions"]["delete"],
+                        }
                     ),
                     icon_size=20,
                 ),
@@ -344,7 +381,11 @@ def build_data_table(
             ),
             alignment=ft.alignment.center,
             padding=ft.padding.all(SPACE_4),
-            border=ft.border.only(bottom=ft.BorderSide(1, "#E5E7EB")) if index < total - 1 else None,
+            border=ft.border.only(
+                bottom=ft.BorderSide(1, theme["table"]["divider"])
+            )
+            if index < total - 1
+            else None,
         )
 
         rows.append(row_container)
@@ -353,8 +394,9 @@ def build_data_table(
 
     table = ft.Container(
         content=ft.Column([header_row, body], spacing=0),
-        border=ft.border.all(1, "#E5E7EB"),
+        border=ft.border.all(1, theme["table"]["divider"]),
         clip_behavior=ft.ClipBehavior.HARD_EDGE,
+        bgcolor=theme["table"]["card_bg"],
     )
 
     return table
@@ -366,6 +408,7 @@ def build_grouped_data_tables(
     editar_cb: Callable[[Ata], None],
     excluir_cb: Callable[[Ata], None],
     filtro: str = "todos",
+    theme: dict | None = None,
 ) -> ft.Container:
     """Return layout with status cards for the given ``atas`` respecting ``filtro``.
 
@@ -383,6 +426,7 @@ def build_grouped_data_tables(
     # ``todos`` deve exibir todos os tipos de status disponíveis
     statuses = [filtro] if filtro != "todos" else list(STATUS_INFO.keys())
 
+    theme = theme or {}
     card_controls: list[ft.Control] = []
     for status in statuses:
         atas_status = groups.get(status, [])
@@ -408,9 +452,10 @@ def build_grouped_data_tables(
             editar_cb,
             excluir_cb,
             status,
+            theme,
         )
 
-        card = build_card(info["title"], icon, table)
+        card = build_card(info["title"], icon, table, theme=theme)
         card.expand = True
         card_controls.append(card)
 

--- a/src/ui/theme/__init__.py
+++ b/src/ui/theme/__init__.py
@@ -1,3 +1,3 @@
-from . import spacing, shadows
+from . import spacing, shadows, colors
 
-__all__ = ["spacing", "shadows"]
+__all__ = ["spacing", "shadows", "colors"]

--- a/src/ui/theme/colors.py
+++ b/src/ui/theme/colors.py
@@ -1,0 +1,140 @@
+import flet as ft
+
+LIGHT = {
+    "app_bg": ft.colors.GREY_100,
+    "text": ft.colors.GREY_900,
+    "sidebar": {
+        "bg": ft.colors.WHITE,
+        "title": ft.colors.INDIGO_500,
+        "link": ft.colors.GREY_700,
+        "link_hover_bg": ft.colors.INDIGO_100,
+        "link_hover_text": ft.colors.INDIGO_600,
+        "link_active_bg": ft.colors.INDIGO_50,
+        "link_active_text": ft.colors.INDIGO_600,
+        "toggle_bg": ft.colors.GREY_100,
+        "icon_sun": ft.colors.AMBER_400,
+        "icon_moon": ft.colors.GREY_500,
+    },
+    "header": {
+        "bg": ft.colors.WHITE,
+        "title": ft.colors.GREY_900,
+        "search_bg": ft.colors.GREY_100,
+        "search_text": ft.colors.GREY_900,
+        "search_placeholder": ft.colors.GREY_900,
+        "search_icon": ft.colors.GREY_400,
+        "search_focus": ft.colors.INDIGO_500,
+        "button_bg": ft.colors.INDIGO_600,
+        "button_text": ft.colors.WHITE,
+        "button_hover_bg": ft.colors.INDIGO_700,
+    },
+    "tabs": {
+        "border": ft.colors.GREY_200,
+        "text": ft.colors.GREY_500,
+        "hover": ft.colors.GREY_700,
+        "active_border": ft.colors.INDIGO_500,
+        "active_text": ft.colors.INDIGO_600,
+    },
+    "table": {
+        "card_bg": ft.colors.WHITE,
+        "title_text": ft.colors.GREY_900,
+        "header_border": ft.colors.GREY_200,
+        "header_bg": ft.colors.GREY_50,
+        "header_text": ft.colors.GREY_500,
+        "number_text": ft.colors.GREY_900,
+        "other_text": ft.colors.GREY_500,
+        "divider": ft.colors.GREY_200,
+        "no_record": ft.colors.GREY_500,
+    },
+    "badges": {
+        "vigente_bg": ft.colors.GREEN_100,
+        "vigente_text": ft.colors.GREEN_800,
+        "a_vencer_bg": ft.colors.YELLOW_100,
+        "a_vencer_text": ft.colors.YELLOW_800,
+        "vencida_bg": ft.colors.RED_100,
+        "vencida_text": ft.colors.RED_800,
+    },
+    "actions": {
+        "view": ft.colors.INDIGO_600,
+        "view_hover": ft.colors.INDIGO_900,
+        "edit": ft.colors.GREY_600,
+        "edit_hover": ft.colors.GREY_900,
+        "delete": ft.colors.RED_600,
+        "delete_hover": ft.colors.RED_900,
+    },
+}
+
+DARK = {
+    "app_bg": ft.colors.GREY_900,
+    "text": ft.colors.WHITE,
+    "sidebar": {
+        "bg": ft.colors.GREY_800,
+        "title": ft.colors.INDIGO_500,
+        "link": ft.colors.GREY_300,
+        "link_hover_bg": ft.colors.INDIGO_900,
+        "link_hover_text": ft.colors.INDIGO_300,
+        "link_active_bg": ft.colors.INDIGO_900,
+        "link_active_text": ft.colors.INDIGO_300,
+        "toggle_bg": ft.colors.GREY_700,
+        "icon_sun": ft.colors.AMBER_400,
+        "icon_moon": ft.colors.GREY_500,
+    },
+    "header": {
+        "bg": ft.colors.GREY_800,
+        "title": ft.colors.WHITE,
+        "search_bg": ft.colors.GREY_700,
+        "search_text": ft.colors.WHITE,
+        "search_placeholder": ft.colors.WHITE,
+        "search_icon": ft.colors.GREY_400,
+        "search_focus": ft.colors.INDIGO_500,
+        "button_bg": ft.colors.INDIGO_600,
+        "button_text": ft.colors.WHITE,
+        "button_hover_bg": ft.colors.INDIGO_700,
+    },
+    "tabs": {
+        "border": ft.colors.GREY_700,
+        "text": ft.colors.GREY_400,
+        "hover": ft.colors.GREY_200,
+        "active_border": ft.colors.INDIGO_500,
+        "active_text": ft.colors.INDIGO_400,
+    },
+    "table": {
+        "card_bg": ft.colors.GREY_800,
+        "title_text": ft.colors.WHITE,
+        "header_border": ft.colors.GREY_700,
+        "header_bg": ft.colors.GREY_700,
+        "header_text": ft.colors.GREY_300,
+        "number_text": ft.colors.WHITE,
+        "other_text": ft.colors.GREY_400,
+        "divider": ft.colors.GREY_700,
+        "no_record": ft.colors.GREY_400,
+    },
+    "badges": {
+        "vigente_bg": ft.colors.GREEN_900,
+        "vigente_text": ft.colors.GREEN_300,
+        "a_vencer_bg": ft.colors.YELLOW_900,
+        "a_vencer_text": ft.colors.YELLOW_300,
+        "vencida_bg": ft.colors.RED_900,
+        "vencida_text": ft.colors.RED_300,
+    },
+    "actions": {
+        "view": ft.colors.INDIGO_400,
+        "view_hover": ft.colors.INDIGO_300,
+        "edit": ft.colors.GREY_400,
+        "edit_hover": ft.colors.GREY_300,
+        "delete": ft.colors.RED_400,
+        "delete_hover": ft.colors.RED_300,
+    },
+}
+
+
+COLORS = {
+    "light": LIGHT,
+    "dark": DARK,
+}
+
+def get_theme(mode: ft.ThemeMode | str):
+    if isinstance(mode, ft.ThemeMode):
+        mode = "dark" if mode == ft.ThemeMode.DARK else "light"
+    return COLORS.get(str(mode).lower(), LIGHT)
+
+__all__ = ["LIGHT", "DARK", "COLORS", "get_theme"]

--- a/src/ui/tokens.py
+++ b/src/ui/tokens.py
@@ -86,7 +86,10 @@ def build_section(
         border_radius=8,
     )
 
-def build_card(title: str, icon: ft.Control, content: ft.Control) -> ft.Control:
+def build_card(
+    title: str, icon: ft.Control, content: ft.Control, *, theme: dict | None = None
+) -> ft.Control:
+    theme = theme or {}
     header = ft.Row(
         [
             icon,
@@ -94,7 +97,7 @@ def build_card(title: str, icon: ft.Control, content: ft.Control) -> ft.Control:
                 title,
                 size=16,
                 weight=ft.FontWeight.W_600,
-                color="#1F2937",
+                color=theme.get("table", {}).get("title_text", "#1F2937"),
             ),
         ],
         spacing=SPACE_2,
@@ -105,6 +108,6 @@ def build_card(title: str, icon: ft.Control, content: ft.Control) -> ft.Control:
         padding=SPACE_4,
         border=ft.border.all(1, GREY_LIGHT),
         border_radius=8,
-        bgcolor=ft.colors.WHITE,
+        bgcolor=theme.get("table", {}).get("card_bg", ft.colors.WHITE),
         shadow=SHADOW_MD,
     )


### PR DESCRIPTION
## Summary
- centralize light and dark color definitions for the UI
- apply the new color tokens across navigation, header, search, and data tables
- rebuild UI on theme toggle to update colors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689257d2e87c8322ac83ef71056a5d31