### PR TITLE
fix: handle search icon color

### DIFF
--- a/src/ui/main_view.py
+++ b/src/ui/main_view.py
@@ -163,8 +163,10 @@ def build_search(on_change: Callable, value: str = "", theme: dict = None) -> tu
     theme = theme or {}
     search_field = ft.TextField(
         hint_text="Buscar atas...",
-        prefix_icon=ft.icons.SEARCH,
-        prefix_icon_color=theme.get("header", {}).get("search_icon"),
+        prefix=ft.Icon(
+            ft.icons.SEARCH,
+            color=theme.get("header", {}).get("search_icon"),
+        ),
         on_change=on_change,
         value=value,
         expand=True,


### PR DESCRIPTION
## Summary
- avoid unsupported prefix_icon_color property
- specify search icon color using explicit Icon control

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68925d8fc9f08322b2a3c2398d62e717