### PR TITLE
feat: add typography tokens and apply font styles

### DIFF
--- a/src/main_gui.py
+++ b/src/main_gui.py
@@ -23,6 +23,7 @@ from ui import build_ata_detail_view
 from ui.theme.spacing import SPACE_2, SPACE_4, SPACE_5
 from ui.theme.shadows import SHADOW_XL
 from ui.responsive import get_breakpoint
+from ui.theme.typography import FONT_SANS
 
 class AtaApp:
     def __init__(self, page: ft.Page):
@@ -50,8 +51,8 @@ class AtaApp:
         # Remove outer page padding to ensure consistent gutter handled by body container
         self.page.padding = 0
         self.page.bgcolor = "#F3F4F6"
-        self.page.fonts = {"Inter": "https://fonts.gstatic.com/s/inter/v7/Inter-Regular.ttf"}
-        self.page.theme = ft.Theme(font_family="Inter")
+        self.page.fonts = {FONT_SANS: "https://fonts.gstatic.com/s/inter/v7/Inter-Regular.ttf"}
+        self.page.theme = ft.Theme(font_family=FONT_SANS)
         self.page.on_resize = self.on_page_resize
     
     def build_ui(self):

--- a/src/ui/main_view.py
+++ b/src/ui/main_view.py
@@ -11,6 +11,15 @@ try:
         SPACE_6,
     )
     from .tokens import build_card, primary_button
+    from .theme.typography import (
+        text,
+        text_style,
+        FONT_BOLD,
+        TEXT_SM,
+        TEXT_XL,
+        LEADING_5,
+        TRACKING_WIDER,
+    )
 except Exception:  # pragma: no cover - fallback for standalone execution
     from theme.spacing import (
         SPACE_1,
@@ -21,6 +30,15 @@ except Exception:  # pragma: no cover - fallback for standalone execution
         SPACE_6,
     )
     from tokens import build_card, primary_button
+    from theme.typography import (
+        text,
+        text_style,
+        FONT_BOLD,
+        TEXT_SM,
+        TEXT_XL,
+        LEADING_5,
+        TRACKING_WIDER,
+    )
 
 try:
     from ..models.ata import Ata
@@ -95,7 +113,13 @@ def build_header(
     return ft.AppBar(
         leading=ft.Icon(ft.icons.DESCRIPTION_OUTLINED),
         leading_width=40,
-        title=ft.Text("Ata de Registro de Preços"),
+        title=text(
+            "Ata de Registro de Preços",
+            size=TEXT_XL,
+            weight=FONT_BOLD,
+            line_height=LEADING_5,
+            letter_spacing=TRACKING_WIDER,
+        ),
         bgcolor=ft.colors.INVERSE_PRIMARY,
         actions=[
             ft.Container(
@@ -158,11 +182,19 @@ def build_search(on_change: Callable, value: str = "") -> tuple[ft.Container, ft
         value=value,
         expand=True,
         height=40,
-        text_style=ft.TextStyle(
-            size=14, weight=ft.FontWeight.W_500, color=ft.colors.GREY_900
+        text_style=text_style(
+            size=TEXT_SM,
+            weight=ft.FontWeight.W_500,
+            line_height=LEADING_5,
+            letter_spacing=TRACKING_WIDER,
+            color=ft.colors.GREY_900,
         ),
-        hint_style=ft.TextStyle(
-            size=14, weight=ft.FontWeight.W_500, color=ft.colors.GREY_900
+        hint_style=text_style(
+            size=TEXT_SM,
+            weight=ft.FontWeight.W_500,
+            line_height=LEADING_5,
+            letter_spacing=TRACKING_WIDER,
+            color=ft.colors.GREY_900,
         ),
         border_radius=9999,
         border_color=ft.colors.GREY_300,

--- a/src/ui/theme/__init__.py
+++ b/src/ui/theme/__init__.py
@@ -1,3 +1,3 @@
-from . import spacing, shadows
+from . import spacing, shadows, typography
 
-__all__ = ["spacing", "shadows"]
+__all__ = ["spacing", "shadows", "typography"]

--- a/src/ui/theme/typography.py
+++ b/src/ui/theme/typography.py
@@ -1,0 +1,58 @@
+import flet as ft
+
+# Default sans-serif font family used across the application
+FONT_SANS = "Inter"
+
+# Text size tokens (TailwindCSS equivalents)
+TEXT_XL = 20  # text-xl
+TEXT_SM = 14  # text-sm
+
+# Font weight tokens
+FONT_BOLD = ft.FontWeight.BOLD
+
+# Line height and letter spacing tokens
+# Approximation of Tailwind's leading-5 and tracking-wider
+LEADING_5 = 1.25
+TRACKING_WIDER = 0.05
+
+def text(
+    value: str,
+    *,
+    size: int | float = TEXT_SM,
+    weight: ft.FontWeight | None = None,
+    line_height: float | None = None,
+    letter_spacing: float | None = None,
+    color: str | None = None,
+    **kwargs,
+) -> ft.Text:
+    """Create a Text control with the project default font settings."""
+    return ft.Text(
+        value,
+        style=ft.TextStyle(
+            font_family=FONT_SANS,
+            size=size,
+            weight=weight,
+            height=line_height,
+            letter_spacing=letter_spacing,
+            color=color,
+        ),
+        **kwargs,
+    )
+
+def text_style(
+    *,
+    size: int | float = TEXT_SM,
+    weight: ft.FontWeight | None = None,
+    line_height: float | None = None,
+    letter_spacing: float | None = None,
+    color: str | None = None,
+) -> ft.TextStyle:
+    """Return a TextStyle with default font family and given parameters."""
+    return ft.TextStyle(
+        font_family=FONT_SANS,
+        size=size,
+        weight=weight,
+        height=line_height,
+        letter_spacing=letter_spacing,
+        color=color,
+    )

--- a/src/ui/tokens.py
+++ b/src/ui/tokens.py
@@ -7,6 +7,13 @@ from .theme.spacing import (
     SPACE_6,
 )
 from .theme.shadows import SHADOW_MD
+from .theme.typography import (
+    text,
+    FONT_BOLD,
+    LEADING_5,
+    TRACKING_WIDER,
+    TEXT_XL,
+)
 
 import flet as ft
 from typing import Callable, Optional
@@ -73,7 +80,14 @@ def build_section(
                 padding=SPACE_2,
                 border_radius=8,
             ),
-            ft.Text(title, size=20, weight=ft.FontWeight.BOLD, color="#1F2937"),
+            text(
+                title,
+                size=TEXT_XL,
+                weight=FONT_BOLD,
+                line_height=LEADING_5,
+                letter_spacing=TRACKING_WIDER,
+                color="#1F2937",
+            ),
         ],
         spacing=SPACE_3,
         vertical_alignment=ft.CrossAxisAlignment.CENTER,
@@ -90,10 +104,12 @@ def build_card(title: str, icon: ft.Control, content: ft.Control) -> ft.Control:
     header = ft.Row(
         [
             icon,
-            ft.Text(
+            text(
                 title,
                 size=16,
                 weight=ft.FontWeight.W_600,
+                line_height=LEADING_5,
+                letter_spacing=TRACKING_WIDER,
                 color="#1F2937",
             ),
         ],


### PR DESCRIPTION
## Summary
- add typography tokens and helpers for fonts, sizes and spacing
- apply default sans-serif font globally
- refactor UI text components to use new typography utilities

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68926304d4e08322b15336ac95421351