### PR TITLE
Remove theme and color seed logic

### DIFF
--- a/src/main_gui.py
+++ b/src/main_gui.py
@@ -23,7 +23,6 @@ from ui import build_ata_detail_view
 from ui.theme.spacing import SPACE_2, SPACE_4, SPACE_5
 from ui.theme.shadows import SHADOW_XL
 from ui.responsive import get_breakpoint
-from ui.theme.typography import FONT_SANS
 
 class AtaApp:
     def __init__(self, page: ft.Page):
@@ -47,12 +46,9 @@ class AtaApp:
         self.page.title = "Ata de Registro de Preços 0016/2024"
         self.page.window_width = 1200
         self.page.window_height = 800
-        self.page.theme_mode = ft.ThemeMode.LIGHT
         # Remove outer page padding to ensure consistent gutter handled by body container
         self.page.padding = 0
         self.page.bgcolor = "#F3F4F6"
-        self.page.fonts = {FONT_SANS: "https://fonts.gstatic.com/s/inter/v7/Inter-Regular.ttf"}
-        self.page.theme = ft.Theme(font_family=FONT_SANS)
         self.page.on_resize = self.on_page_resize
     
     def build_ui(self):

--- a/src/ui/navigation_menu.py
+++ b/src/ui/navigation_menu.py
@@ -5,19 +5,6 @@ try:
 except Exception:  # pragma: no cover
     from theme.spacing import SPACE_2, SPACE_3, SPACE_4, SPACE_5
 
-class PopupColorItem(ft.PopupMenuItem):
-    def __init__(self, color: str, name: str):
-        super().__init__()
-        self.content = ft.Row(
-            controls=[ft.Icon(name=ft.icons.COLOR_LENS_OUTLINED, color=color), ft.Text(name)]
-        )
-        self.data = color
-        self.on_click = self.seed_color_changed
-
-    def seed_color_changed(self, e):
-        self.page.theme = self.page.dark_theme = ft.Theme(color_scheme_seed=self.data)
-        self.page.update()
-
 class NavigationDestination:
     def __init__(self, name: str, label: str, icon: str, selected_icon: str, index: int):
         self.name = name
@@ -96,52 +83,9 @@ class LeftNavigationMenu(ft.Column):
             NavigationDestination("vencimentos", "Vencimentos", ft.icons.ALARM_OUTLINED, ft.icons.ALARM, 2),
         ]
         self.rail = NavigationColumn(app, self.destinations)
-        self.dark_light_text = ft.Text("Light theme")
-        self.dark_light_icon = ft.IconButton(icon=ft.icons.BRIGHTNESS_2_OUTLINED, tooltip="Toggle brightness", on_click=self.theme_changed)
         self.padding = 0
         self.spacing = SPACE_3
-        self.controls = [
-            self.rail,
-            ft.Container(
-                padding=ft.padding.only(top=SPACE_5),
-                content=ft.Column(
-                    expand=1,
-                    spacing=SPACE_3,
-                    alignment=ft.MainAxisAlignment.END,
-                    controls=[
-                        ft.Row([self.dark_light_icon, self.dark_light_text], spacing=SPACE_2),
-                        ft.Row([
-                            ft.PopupMenuButton(
-                                icon=ft.icons.COLOR_LENS_OUTLINED,
-                                items=[
-                                    PopupColorItem(color="deeppurple", name="Deep purple"),
-                                    PopupColorItem(color="indigo", name="Indigo"),
-                                    PopupColorItem(color="blue", name="Blue"),
-                                    PopupColorItem(color="teal", name="Teal"),
-                                    PopupColorItem(color="green", name="Green"),
-                                    PopupColorItem(color="yellow", name="Yellow"),
-                                    PopupColorItem(color="orange", name="Orange"),
-                                    PopupColorItem(color="deeporange", name="Deep orange"),
-                                    PopupColorItem(color="pink", name="Pink"),
-                                ],
-                            ),
-                            ft.Text("Seed color"),
-                        ], spacing=SPACE_2)
-                    ],
-                ),
-            ),
-        ]
-
-    def theme_changed(self, e):
-        if self.page.theme_mode == ft.ThemeMode.LIGHT:
-            self.page.theme_mode = ft.ThemeMode.DARK
-            self.dark_light_text.value = "Dark theme"
-            self.dark_light_icon.icon = ft.icons.BRIGHTNESS_HIGH
-        else:
-            self.page.theme_mode = ft.ThemeMode.LIGHT
-            self.dark_light_text.value = "Light theme"
-            self.dark_light_icon.icon = ft.icons.BRIGHTNESS_2
-        self.page.update()
+        self.controls = [self.rail]
 
     def update_layout(self, width: int):
         self.rail.update_layout(width)


### PR DESCRIPTION
## Summary
- drop navigation menu theme toggle and seed color picker
- clean page setup by removing theme configuration

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_6892a015397083228ff27248d228737f