### PR TITLE
Remove seed color customization and default to blue

### DIFF
--- a/src/main_gui.py
+++ b/src/main_gui.py
@@ -52,7 +52,8 @@ class AtaApp:
         self.page.padding = 0
         self.page.bgcolor = "#F3F4F6"
         self.page.fonts = {FONT_SANS: "https://fonts.gstatic.com/s/inter/v7/Inter-Regular.ttf"}
-        self.page.theme = ft.Theme(font_family=FONT_SANS)
+        self.page.theme = ft.Theme(color_scheme_seed="blue", font_family=FONT_SANS)
+        self.page.dark_theme = ft.Theme(color_scheme_seed="blue", font_family=FONT_SANS)
         self.page.on_resize = self.on_page_resize
     
     def build_ui(self):

--- a/src/ui/navigation_menu.py
+++ b/src/ui/navigation_menu.py
@@ -1,22 +1,9 @@
 import flet as ft
 
 try:
-    from .theme.spacing import SPACE_2, SPACE_3, SPACE_4, SPACE_5
+    from .theme.spacing import SPACE_2, SPACE_3, SPACE_5
 except Exception:  # pragma: no cover
-    from theme.spacing import SPACE_2, SPACE_3, SPACE_4, SPACE_5
-
-class PopupColorItem(ft.PopupMenuItem):
-    def __init__(self, color: str, name: str):
-        super().__init__()
-        self.content = ft.Row(
-            controls=[ft.Icon(name=ft.icons.COLOR_LENS_OUTLINED, color=color), ft.Text(name)]
-        )
-        self.data = color
-        self.on_click = self.seed_color_changed
-
-    def seed_color_changed(self, e):
-        self.page.theme = self.page.dark_theme = ft.Theme(color_scheme_seed=self.data)
-        self.page.update()
+    from theme.spacing import SPACE_2, SPACE_3, SPACE_5
 
 class NavigationDestination:
     def __init__(self, name: str, label: str, icon: str, selected_icon: str, index: int):
@@ -109,24 +96,7 @@ class LeftNavigationMenu(ft.Column):
                     spacing=SPACE_3,
                     alignment=ft.MainAxisAlignment.END,
                     controls=[
-                        ft.Row([self.dark_light_icon, self.dark_light_text], spacing=SPACE_2),
-                        ft.Row([
-                            ft.PopupMenuButton(
-                                icon=ft.icons.COLOR_LENS_OUTLINED,
-                                items=[
-                                    PopupColorItem(color="deeppurple", name="Deep purple"),
-                                    PopupColorItem(color="indigo", name="Indigo"),
-                                    PopupColorItem(color="blue", name="Blue"),
-                                    PopupColorItem(color="teal", name="Teal"),
-                                    PopupColorItem(color="green", name="Green"),
-                                    PopupColorItem(color="yellow", name="Yellow"),
-                                    PopupColorItem(color="orange", name="Orange"),
-                                    PopupColorItem(color="deeporange", name="Deep orange"),
-                                    PopupColorItem(color="pink", name="Pink"),
-                                ],
-                            ),
-                            ft.Text("Seed color"),
-                        ], spacing=SPACE_2)
+                        ft.Row([self.dark_light_icon, self.dark_light_text], spacing=SPACE_2)
                     ],
                 ),
             ),


### PR DESCRIPTION
## Summary
- Set both light and dark themes to use a blue color scheme by default
- Remove seed color selection from the navigation menu

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892a1b9b9c48322baebe206094ddd8b