### PR TITLE
refactor: replace fragile relative imports

### DIFF
--- a/src/forms/ata_form.py
+++ b/src/forms/ata_form.py
@@ -2,36 +2,19 @@ import flet as ft
 from datetime import date, datetime
 from typing import List, Dict, Any, Optional, Callable
 
-try:
-    from ..ui.theme.spacing import (
-        SPACE_1,
-        SPACE_2,
-        SPACE_3,
-        SPACE_4,
-        SPACE_5,
-        SPACE_6,
-    )
-    from ..ui.theme.shadows import SHADOW_LG
-    from ..ui.tokens import build_section, primary_button, secondary_button
-    from ..ui.theme import colors
-except Exception:  # pragma: no cover
-    from ui.theme.spacing import (
-        SPACE_1,
-        SPACE_2,
-        SPACE_3,
-        SPACE_4,
-        SPACE_5,
-        SPACE_6,
-    )
-    from ui.theme.shadows import SHADOW_LG
-    from ui.tokens import build_section, primary_button, secondary_button
-    from ui.theme import colors
-try:
-    from ..models.ata import Ata, Item
-    from ..utils.validators import Validators, Formatters, MaskUtils
-except ImportError:  # Execução direta sem pacote
-    from models.ata import Ata, Item
-    from utils.validators import Validators, Formatters, MaskUtils
+from ui.theme.spacing import (
+    SPACE_1,
+    SPACE_2,
+    SPACE_3,
+    SPACE_4,
+    SPACE_5,
+    SPACE_6,
+)
+from ui.theme.shadows import SHADOW_LG
+from ui.tokens import build_section, primary_button, secondary_button
+from ui.theme import colors
+from models.ata import Ata, Item
+from utils.validators import Validators, Formatters, MaskUtils
 
 class AtaForm:
     """Formulário para criação e edição de atas"""

--- a/src/services/alert_service.py
+++ b/src/services/alert_service.py
@@ -1,13 +1,8 @@
 from datetime import date, datetime, timedelta
 from typing import List, Dict, Any
 
-# Importações condicionais para suportar execução direta e como módulo
-try:
-    from ..models.ata import Ata
-    from ..utils.email_service import EmailService
-except ImportError:
-    from models.ata import Ata
-    from utils.email_service import EmailService
+from models.ata import Ata
+from utils.email_service import EmailService
 
 class AlertService:
     """Serviço para gerenciar alertas automáticos"""

--- a/src/services/ata_service.py
+++ b/src/services/ata_service.py
@@ -3,11 +3,7 @@ import os
 from typing import List, Dict, Any, Optional
 from datetime import date, datetime
 
-# Importações condicionais para suportar execução direta e como módulo
-try:
-    from ..models.ata import Ata, Item
-except ImportError:
-    from models.ata import Ata, Item
+from models.ata import Ata, Item
 
 class AtaService:
     """Serviço para gerenciar operações CRUD das atas"""

--- a/src/services/sqlite_ata_service.py
+++ b/src/services/sqlite_ata_service.py
@@ -2,10 +2,7 @@ import sqlite3
 from typing import List, Dict, Any, Optional
 from datetime import date, datetime
 
-try:
-    from ..models.ata import Ata, Item
-except ImportError:  # pragma: no cover - support execution without package
-    from models.ata import Ata, Item
+from models.ata import Ata, Item
 
 class SQLiteAtaService:
     """Serviço de Atas usando SQLite como persistência."""

--- a/src/ui/ata_detail_view.py
+++ b/src/ui/ata_detail_view.py
@@ -2,37 +2,20 @@ import flet as ft
 from datetime import timedelta
 from typing import Callable
 
-try:
-    from .theme.spacing import (
-        SPACE_1,
-        SPACE_2,
-        SPACE_3,
-        SPACE_4,
-        SPACE_5,
-        SPACE_6,
-    )
-    from .theme.shadows import SHADOW_LG
-    from .tokens import build_section, primary_button, secondary_button
-    from .theme import colors
-except Exception:  # pragma: no cover
-    from theme.spacing import (
-        SPACE_1,
-        SPACE_2,
-        SPACE_3,
-        SPACE_4,
-        SPACE_5,
-        SPACE_6,
-    )
-    from theme.shadows import SHADOW_LG
-    from tokens import build_section, primary_button, secondary_button
-    from theme import colors
+from .theme.spacing import (
+    SPACE_1,
+    SPACE_2,
+    SPACE_3,
+    SPACE_4,
+    SPACE_5,
+    SPACE_6,
+)
+from .theme.shadows import SHADOW_LG
+from .tokens import build_section, primary_button, secondary_button
+from .theme import colors
 
-try:
-    from ..models.ata import Ata
-    from ..utils.validators import Formatters
-except ImportError:  # standalone execution
-    from models.ata import Ata
-    from utils.validators import Formatters
+from models.ata import Ata
+from utils.validators import Formatters
 
 
 def build_ata_detail_view(

--- a/src/ui/main_view.py
+++ b/src/ui/main_view.py
@@ -1,57 +1,30 @@
 import flet as ft
 from typing import Callable, List
 
-try:
-    from .theme.spacing import (
-        SPACE_1,
-        SPACE_2,
-        SPACE_3,
-        SPACE_4,
-        SPACE_5,
-        SPACE_6,
-    )
-    from .tokens import build_card, primary_button
-    from .theme.typography import (
-        text,
-        text_style,
-        FONT_BOLD,
-        TEXT_SM,
-        TEXT_XL,
-        LEADING_5,
-        TRACKING_WIDER,
-    )
-    from .theme import colors
-    from ..utils.color_utils import get_status_colors
-except Exception:  # pragma: no cover - fallback for standalone execution
-    from theme.spacing import (
-        SPACE_1,
-        SPACE_2,
-        SPACE_3,
-        SPACE_4,
-        SPACE_5,
-        SPACE_6,
-    )
-    from tokens import build_card, primary_button
-    from theme.typography import (
-        text,
-        text_style,
-        FONT_BOLD,
-        TEXT_SM,
-        TEXT_XL,
-        LEADING_5,
-        TRACKING_WIDER,
-    )
-    from theme import colors
-    from utils.color_utils import get_status_colors
+from .theme.spacing import (
+    SPACE_1,
+    SPACE_2,
+    SPACE_3,
+    SPACE_4,
+    SPACE_5,
+    SPACE_6,
+)
+from .tokens import build_card, primary_button
+from .theme.typography import (
+    text,
+    text_style,
+    FONT_BOLD,
+    TEXT_SM,
+    TEXT_XL,
+    LEADING_5,
+    TRACKING_WIDER,
+)
+from .theme import colors
+from utils.color_utils import get_status_colors
 
-try:
-    from ..models.ata import Ata
-    from ..utils.validators import Formatters
-    from ..utils.chart_utils import ChartUtils
-except ImportError:  # for standalone execution
-    from models.ata import Ata
-    from utils.validators import Formatters
-    from utils.chart_utils import ChartUtils
+from models.ata import Ata
+from utils.validators import Formatters
+from utils.chart_utils import ChartUtils
 
 
 STATUS_INFO = {

--- a/src/utils/chart_utils.py
+++ b/src/utils/chart_utils.py
@@ -2,30 +2,15 @@ import flet as ft
 from typing import List, Dict, Any, Tuple
 from datetime import date, datetime, timedelta
 
-# Importações condicionais para suportar execução direta e como módulo
-try:
-    from ..models.ata import Ata
-except ImportError:
-    from models.ata import Ata
-
-try:
-    from ..ui.theme.spacing import (
-        SPACE_1,
-        SPACE_2,
-        SPACE_3,
-        SPACE_4,
-        SPACE_5,
-        SPACE_6,
-    )
-except Exception:  # pragma: no cover
-    from ui.theme.spacing import (
-        SPACE_1,
-        SPACE_2,
-        SPACE_3,
-        SPACE_4,
-        SPACE_5,
-        SPACE_6,
-    )
+from models.ata import Ata
+from ui.theme.spacing import (
+    SPACE_1,
+    SPACE_2,
+    SPACE_3,
+    SPACE_4,
+    SPACE_5,
+    SPACE_6,
+)
 
 class ChartUtils:
     """Utilitários para criação de gráficos e visualizações"""

--- a/src/utils/color_utils.py
+++ b/src/utils/color_utils.py
@@ -1,9 +1,6 @@
 from typing import Tuple
 
-try:
-    from ..ui.theme import colors
-except Exception:  # pragma: no cover
-    from ui.theme import colors
+from ui.theme import colors
 
 # Mapping from status string to (text_color, background_color)
 _STATUS_COLORS: dict[str, Tuple[str, str]] = {

--- a/src/utils/email_service.py
+++ b/src/utils/email_service.py
@@ -1,11 +1,7 @@
 from datetime import date
 from typing import List
 
-# Importações condicionais para suportar execução direta e como módulo
-try:
-    from ..models.ata import Ata
-except ImportError:
-    from models.ata import Ata
+from models.ata import Ata
 
 class EmailService:
     """Serviço para envio de emails (simulado com print)"""

--- a/src/utils/scheduler.py
+++ b/src/utils/scheduler.py
@@ -3,13 +3,8 @@ import time
 from datetime import datetime, time as dt_time
 from typing import Callable, Dict, Any
 
-# Importações condicionais para suportar execução direta e como módulo
-try:
-    from ..services.alert_service import AlertService
-    from ..services.ata_service import AtaService
-except ImportError:
-    from services.alert_service import AlertService
-    from services.ata_service import AtaService
+from services.alert_service import AlertService
+from services.ata_service import AtaService
 
 class TaskScheduler:
     """Agendador de tarefas para verificações automáticas"""


### PR DESCRIPTION
## Summary
- fix import errors by using explicit package references for utils and theme modules
- clean up conditional import fallbacks across forms, services and utilities

## Testing
- `python test_imports.py`


------
https://chatgpt.com/codex/tasks/task_e_6892df9272e88322bb7855db586c2e0f