### PR TITLE
refactor: apply new color scheme

### DIFF
--- a/src/ui/main_view.py
+++ b/src/ui/main_view.py
@@ -96,8 +96,9 @@ def build_header(
             weight=FONT_BOLD,
             line_height=LEADING_5,
             letter_spacing=TRACKING_WIDER,
+            color=colors.TEXT_DARK,
         ),
-        bgcolor=ft.colors.INVERSE_PRIMARY,
+        bgcolor=colors.HEADER_BG,
         actions=[
             ft.Container(
                 content=actions_row,
@@ -155,6 +156,7 @@ def build_search(on_change: Callable, value: str = "") -> tuple[ft.Container, ft
     search_field = ft.TextField(
         hint_text="Buscar atas...",
         prefix_icon=ft.icons.SEARCH,
+        prefix_icon_color=ft.colors.GREY_400,
         on_change=on_change,
         value=value,
         expand=True,
@@ -171,12 +173,12 @@ def build_search(on_change: Callable, value: str = "") -> tuple[ft.Container, ft
             weight=ft.FontWeight.W_500,
             line_height=LEADING_5,
             letter_spacing=TRACKING_WIDER,
-            color=colors.TEXT_DARK,
+            color=colors.TEXT_SECONDARY,
         ),
         border_radius=9999,
         border_color=colors.GREY_LIGHT,
         focused_border_color=colors.FOCUSED_BORDER,
-        bgcolor=colors.WHITE,
+        bgcolor=ft.colors.GREY_100,
         hover_color=ft.colors.with_opacity(0.08, ft.colors.BLACK),
         content_padding=ft.padding.symmetric(horizontal=SPACE_4, vertical=0),
     )
@@ -240,7 +242,7 @@ def build_data_table(
         ),
         alignment=ft.alignment.center,
         padding=ft.padding.symmetric(vertical=SPACE_4, horizontal=SPACE_4),
-        bgcolor=colors.HEADER_BG,
+        bgcolor=colors.TABLE_HEAD_BG,
         border=ft.border.only(bottom=ft.BorderSide(1, colors.GREY_LIGHT)),
     )
 
@@ -260,6 +262,7 @@ def build_data_table(
             ),
             ft.Text(
                 data_formatada,
+                color=colors.TEXT_SECONDARY,
                 max_lines=1,
                 no_wrap=True,
                 overflow=ft.TextOverflow.ELLIPSIS,
@@ -267,6 +270,7 @@ def build_data_table(
             ),
             ft.Text(
                 ata.objeto,
+                color=colors.TEXT_SECONDARY,
                 max_lines=1,
                 no_wrap=True,
                 overflow=ft.TextOverflow.ELLIPSIS,
@@ -274,6 +278,7 @@ def build_data_table(
             ),
             ft.Text(
                 ata.fornecedor,
+                color=colors.TEXT_SECONDARY,
                 max_lines=1,
                 no_wrap=True,
                 overflow=ft.TextOverflow.ELLIPSIS,
@@ -303,7 +308,10 @@ def build_data_table(
                     tooltip="Visualizar",
                     on_click=lambda e, ata=ata: visualizar_cb(ata),
                     style=ft.ButtonStyle(
-                        color={ft.MaterialState.HOVERED: colors.BLUE_HOVER, "": colors.TEXT_SECONDARY}
+                        color={
+                            ft.MaterialState.HOVERED: ft.colors.INDIGO_900,
+                            "": ft.colors.INDIGO_600,
+                        }
                     ),
                     icon_size=20,
                 ),
@@ -312,7 +320,10 @@ def build_data_table(
                     tooltip="Editar",
                     on_click=lambda e, ata=ata: editar_cb(ata),
                     style=ft.ButtonStyle(
-                        color={ft.MaterialState.HOVERED: colors.YELLOW, "": colors.TEXT_SECONDARY}
+                        color={
+                            ft.MaterialState.HOVERED: ft.colors.GREY_900,
+                            "": ft.colors.GREY_600,
+                        }
                     ),
                     icon_size=20,
                 ),
@@ -321,7 +332,10 @@ def build_data_table(
                     tooltip="Excluir",
                     on_click=lambda e, ata=ata: excluir_cb(ata),
                     style=ft.ButtonStyle(
-                        color={ft.MaterialState.HOVERED: colors.RED, "": colors.TEXT_SECONDARY}
+                        color={
+                            ft.MaterialState.HOVERED: ft.colors.RED_900,
+                            "": ft.colors.RED_600,
+                        }
                     ),
                     icon_size=20,
                 ),
@@ -358,6 +372,7 @@ def build_data_table(
         content=ft.Column([header_row, body], spacing=0),
         border=ft.border.all(1, colors.GREY_LIGHT),
         clip_behavior=ft.ClipBehavior.HARD_EDGE,
+        bgcolor=colors.WHITE,
     )
 
     return table

--- a/src/ui/navigation_menu.py
+++ b/src/ui/navigation_menu.py
@@ -2,8 +2,10 @@ import flet as ft
 
 try:
     from .theme.spacing import SPACE_2, SPACE_3
+    from .theme import colors
 except Exception:  # pragma: no cover
     from theme.spacing import SPACE_2, SPACE_3
+    from theme import colors
 
 class NavigationDestination:
     def __init__(self, name: str, label: str, icon: str, selected_icon: str, index: int):
@@ -20,11 +22,31 @@ class NavigationItem(ft.Container):
         self.ink = True
         self.padding = SPACE_3
         self.border_radius = 8
+        self.selected = False
         self.content = ft.Row(
             [ft.Icon(destination.icon), ft.Text(destination.label)],
             spacing=SPACE_2,
         )
+        self._set_colors(colors.TEXT_MUTED)
         self.on_click = item_clicked
+        self.on_hover = self._on_hover
+
+    def _set_colors(self, color: str):
+        self.content.controls[0].color = color
+        self.content.controls[1].color = color
+
+    def _on_hover(self, e):
+        if self.selected:
+            self.bgcolor = ft.colors.INDIGO_50
+            self._set_colors(ft.colors.INDIGO_600)
+        else:
+            if e.data == "true":
+                self.bgcolor = ft.colors.INDIGO_100
+                self._set_colors(ft.colors.INDIGO_600)
+            else:
+                self.bgcolor = None
+                self._set_colors(colors.TEXT_MUTED)
+        self.update()
 
     def set_collapsed(self, collapsed: bool):
         """Show only icon when collapsed"""
@@ -68,10 +90,14 @@ class NavigationColumn(ft.Column):
     def update_selected_item(self):
         for item in self.controls:
             item.bgcolor = None
+            item.selected = False
             item.content.controls[0].name = item.destination.icon
+            item._set_colors(colors.TEXT_MUTED)
         sel = self.controls[self.selected_index]
-        sel.bgcolor = ft.colors.SECONDARY_CONTAINER
+        sel.selected = True
+        sel.bgcolor = ft.colors.INDIGO_50
         sel.content.controls[0].name = sel.destination.selected_icon
+        sel._set_colors(ft.colors.INDIGO_600)
 
 class LeftNavigationMenu(ft.Column):
     def __init__(self, app):

--- a/src/ui/theme/colors.py
+++ b/src/ui/theme/colors.py
@@ -2,47 +2,49 @@ import flet as ft
 
 # Base colors
 WHITE = ft.colors.WHITE
-PAGE_BG = "#F3F4F6"
-CARD_BG = "#F8FAFC"
+PAGE_BG = ft.colors.GREY_100
+CARD_BG = ft.colors.WHITE
 
 # Text colors
-TEXT_DARK = "#111827"
-TEXT_PRIMARY = "#1F2937"
-TEXT_SECONDARY = "#6B7280"
-TEXT_MUTED = "#374151"
+TEXT_DARK = ft.colors.GREY_900
+TEXT_PRIMARY = ft.colors.GREY_900
+TEXT_SECONDARY = ft.colors.GREY_500
+TEXT_MUTED = ft.colors.GREY_700
 
 # Button colors
-PRIMARY_BG = "#3B82F6"
-PRIMARY_TEXT = "#FFFFFF"
-SECONDARY_TEXT = "#4B5563"
-SECONDARY_BORDER = "#D1D5DB"
-FOCUSED_BORDER = "#3B82F6"
+PRIMARY_BG = ft.colors.INDIGO_600
+PRIMARY_HOVER = ft.colors.INDIGO_700
+PRIMARY_TEXT = ft.colors.WHITE
+SECONDARY_TEXT = ft.colors.GREY_700
+SECONDARY_BORDER = ft.colors.GREY_200
+FOCUSED_BORDER = ft.colors.INDIGO_500
 
 # Neutral colors
-GREY_LIGHT = "#E5E7EB"
-GREY_DIVIDER = "#9CA3AF"
-HEADER_BG = "#F9FAFB"
+GREY_LIGHT = ft.colors.GREY_200
+GREY_DIVIDER = ft.colors.GREY_200
+HEADER_BG = ft.colors.WHITE
+TABLE_HEAD_BG = ft.colors.GREY_50
 
 # Section colors
-INDIGO = "#4F46E5"
-INDIGO_BG = "#E0E7FF"
-ORANGE = "#EA580C"
-ORANGE_BG = "#FFEDD5"
-TEAL = "#0F766E"
-TEAL_BG = "#CCFBF1"
+INDIGO = ft.colors.INDIGO_500
+INDIGO_BG = ft.colors.INDIGO_100
+ORANGE = ft.colors.ORANGE_600
+ORANGE_BG = ft.colors.ORANGE_100
+TEAL = ft.colors.TEAL_600
+TEAL_BG = ft.colors.TEAL_100
 
 # Status colors
-GREEN = "#16A34A"
-GREEN_BG = "#D1FAE5"
-GREEN_DARK = "#14532D"
-YELLOW = "#CA8A04"
-YELLOW_BG = "#FEF9C3"
-YELLOW_DARK = "#713F12"
-RED = "#DC2626"
-RED_BG = "#FEE2E2"
-RED_DARK = "#991B1B"
-BLUE_HOVER = "#2563EB"
-RESUMO_BG = "#EEF2FF"
+GREEN = ft.colors.GREEN_600
+GREEN_BG = ft.colors.GREEN_100
+GREEN_DARK = ft.colors.GREEN_800
+YELLOW = ft.colors.YELLOW_600
+YELLOW_BG = ft.colors.YELLOW_100
+YELLOW_DARK = ft.colors.YELLOW_800
+RED = ft.colors.RED_600
+RED_BG = ft.colors.RED_100
+RED_DARK = ft.colors.RED_800
+BLUE_HOVER = ft.colors.INDIGO_900
+RESUMO_BG = ft.colors.INDIGO_50
 
 # Semantic aliases
 PRIMARY = ft.colors.BLUE

--- a/src/ui/tokens.py
+++ b/src/ui/tokens.py
@@ -38,9 +38,14 @@ def primary_button(
         text=text,
         icon=icon,
         on_click=on_click,
-        bgcolor=colors.PRIMARY_BG,
         color=colors.PRIMARY_TEXT,
-        style=ft.ButtonStyle(shape=ft.RoundedRectangleBorder(radius=9999)),
+        style=ft.ButtonStyle(
+            shape=ft.RoundedRectangleBorder(radius=9999),
+            bgcolor={
+                ft.MaterialState.DEFAULT: colors.PRIMARY_BG,
+                ft.MaterialState.HOVERED: colors.PRIMARY_HOVER,
+            },
+        ),
         **kwargs,
     )
 


### PR DESCRIPTION
## Summary
- align app colors with updated grey/indigo palette
- style navigation, header, tables and actions with new constants

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892e22677a48322980ffa3db4abb7eb