### PR TITLE
refactor: centralize color definitions

### DIFF
--- a/scripts/check_requirements.py
+++ b/scripts/check_requirements.py
@@ -1,13 +1,23 @@
 import subprocess
 import sys
 import time
+from pathlib import Path
 
 try:
     import importlib.metadata as metadata
 except ImportError:
     import importlib_metadata as metadata  # Python < 3.8
 
-from rich.progress import Progress, SpinnerColumn, BarColumn, TextColumn, TimeElapsedColumn, TaskProgressColumn
+sys.path.append(str(Path(__file__).resolve().parent.parent / "src"))
+from ui.theme import colors
+from rich.progress import (
+    Progress,
+    SpinnerColumn,
+    BarColumn,
+    TextColumn,
+    TimeElapsedColumn,
+    TaskProgressColumn,
+)
 from rich.console import Console
 
 console = Console()
@@ -19,7 +29,7 @@ console.print("[bold cyan]Dependências:[/bold cyan]")
 for p in pkgs:
     try:
         metadata.version(p)
-        console.print(f"  - {p} [green](já instalado)[/green]")
+        console.print(f"  - {p} [{colors.GREEN}](já instalado)[/]")
     except metadata.PackageNotFoundError:
         console.print(f"  - {p}")
 
@@ -32,7 +42,10 @@ with Progress(
     TaskProgressColumn(),
     TimeElapsedColumn(),
 ) as progress:
-    total_task = progress.add_task("[bold green]Progresso total", total=len(pkgs))
+    total_task = progress.add_task(
+        f"[bold {colors.GREEN}]Progresso total",
+        total=len(pkgs),
+    )
     for pkg in pkgs:
         try:
             metadata.version(pkg)

--- a/src/main_gui.py
+++ b/src/main_gui.py
@@ -48,12 +48,11 @@ class AtaApp:
         self.page.title = "Ata de Registro de Preços 0016/2024"
         self.page.window_width = 1200
         self.page.window_height = 800
-        self.page.theme_mode = ft.ThemeMode.LIGHT
         # Remove outer page padding to ensure consistent gutter handled by body container
         self.page.padding = 0
         self.page.bgcolor = colors.PAGE_BG
         self.page.fonts = {FONT_SANS: "https://fonts.gstatic.com/s/inter/v7/Inter-Regular.ttf"}
-        self.page.theme = ft.Theme(color_scheme_seed="blue", font_family=FONT_SANS)
+        self.page.theme = ft.Theme(font_family=FONT_SANS)
         self.page.on_resize = self.on_page_resize
     
     def build_ui(self):
@@ -77,7 +76,7 @@ class AtaApp:
         self.menu_container = ft.Container(
             content=self.navigation_menu,
             width=200,
-            bgcolor=ft.colors.WHITE,
+            bgcolor=colors.WHITE,
             padding=ft.padding.only(
                 left=SPACE_5,
                 right=SPACE_5,

--- a/src/ui/main_view.py
+++ b/src/ui/main_view.py
@@ -96,8 +96,9 @@ def build_header(
             weight=FONT_BOLD,
             line_height=LEADING_5,
             letter_spacing=TRACKING_WIDER,
+            color=colors.TEXT_DARK,
         ),
-        bgcolor=ft.colors.INVERSE_PRIMARY,
+        bgcolor=colors.HEADER_BG,
         actions=[
             ft.Container(
                 content=actions_row,
@@ -117,10 +118,10 @@ def build_filters(filtro_atual: str, filtro_cb: Callable[[str], None]) -> ft.Con
             padding=ft.padding.symmetric(horizontal=12, vertical=8),
             shape=ft.RoundedRectangleBorder(radius=8),
             overlay_color={
-                ft.MaterialState.HOVERED: ft.colors.with_opacity(0.08, ft.colors.BLACK),
-                ft.MaterialState.FOCUSED: ft.colors.with_opacity(0.08, ft.colors.BLACK),
+                ft.MaterialState.HOVERED: colors.HOVER_OVERLAY,
+                ft.MaterialState.FOCUSED: colors.HOVER_OVERLAY,
             },
-            bgcolor=color if selected else ft.colors.TRANSPARENT,
+            bgcolor=color if selected else colors.TRANSPARENT,
             color=colors.WHITE if selected else colors.TEXT_DARK,
             side=None if selected else ft.BorderSide(1, colors.GREY_LIGHT),
         )
@@ -177,7 +178,7 @@ def build_search(on_change: Callable, value: str = "") -> tuple[ft.Container, ft
         border_color=colors.GREY_LIGHT,
         focused_border_color=colors.FOCUSED_BORDER,
         bgcolor=colors.WHITE,
-        hover_color=ft.colors.with_opacity(0.08, ft.colors.BLACK),
+        hover_color=colors.HOVER_OVERLAY,
         content_padding=ft.padding.symmetric(horizontal=SPACE_4, vertical=0),
     )
     return (

--- a/src/ui/navigation_menu.py
+++ b/src/ui/navigation_menu.py
@@ -2,8 +2,10 @@ import flet as ft
 
 try:
     from .theme.spacing import SPACE_2, SPACE_3
+    from .theme import colors
 except Exception:  # pragma: no cover
     from theme.spacing import SPACE_2, SPACE_3
+    from theme import colors
 
 class NavigationDestination:
     def __init__(self, name: str, label: str, icon: str, selected_icon: str, index: int):
@@ -70,7 +72,7 @@ class NavigationColumn(ft.Column):
             item.bgcolor = None
             item.content.controls[0].name = item.destination.icon
         sel = self.controls[self.selected_index]
-        sel.bgcolor = ft.colors.SECONDARY_CONTAINER
+        sel.bgcolor = colors.SECONDARY_CONTAINER
         sel.content.controls[0].name = sel.destination.selected_icon
 
 class LeftNavigationMenu(ft.Column):

--- a/src/ui/theme/colors.py
+++ b/src/ui/theme/colors.py
@@ -2,8 +2,15 @@ import flet as ft
 
 # Base colors
 WHITE = ft.colors.WHITE
+BLACK = ft.colors.BLACK
+BLACK12 = ft.colors.BLACK12
+TRANSPARENT = ft.colors.TRANSPARENT
+
+# Background colors
 PAGE_BG = "#F3F4F6"
 CARD_BG = "#F8FAFC"
+HEADER_BG = "#F9FAFB"
+RESUMO_BG = "#EEF2FF"
 
 # Text colors
 TEXT_DARK = "#111827"
@@ -21,13 +28,14 @@ FOCUSED_BORDER = "#3B82F6"
 # Neutral colors
 GREY_LIGHT = "#E5E7EB"
 GREY_DIVIDER = "#9CA3AF"
-HEADER_BG = "#F9FAFB"
 
 # Section colors
 INDIGO = "#4F46E5"
 INDIGO_BG = "#E0E7FF"
 ORANGE = "#EA580C"
 ORANGE_BG = "#FFEDD5"
+ORANGE_50 = ft.colors.ORANGE_50
+ORANGE_200 = ft.colors.ORANGE_200
 TEAL = "#0F766E"
 TEAL_BG = "#CCFBF1"
 
@@ -35,18 +43,29 @@ TEAL_BG = "#CCFBF1"
 GREEN = "#16A34A"
 GREEN_BG = "#D1FAE5"
 GREEN_DARK = "#14532D"
+GREEN_50 = ft.colors.GREEN_50
+GREEN_200 = ft.colors.GREEN_200
 YELLOW = "#CA8A04"
 YELLOW_BG = "#FEF9C3"
 YELLOW_DARK = "#713F12"
 RED = "#DC2626"
 RED_BG = "#FEE2E2"
 RED_DARK = "#991B1B"
+RED_50 = ft.colors.RED_50
+RED_200 = ft.colors.RED_200
+BLUE = ft.colors.BLUE
+BLUE_50 = ft.colors.BLUE_50
 BLUE_HOVER = "#2563EB"
-RESUMO_BG = "#EEF2FF"
 
 # Semantic aliases
-PRIMARY = ft.colors.BLUE
-DANGER = ft.colors.RED
-SUCCESS = ft.colors.GREEN
-WARNING = ft.colors.ORANGE
-OUTLINE = ft.colors.OUTLINE
+PRIMARY = PRIMARY_BG
+DANGER = RED
+SUCCESS = GREEN
+WARNING = ORANGE
+OUTLINE = SECONDARY_BORDER
+SECONDARY_CONTAINER = GREY_LIGHT
+SURFACE_VARIANT = CARD_BG
+HOVER_OVERLAY = ft.colors.with_opacity(0.08, BLACK)
+
+__all__ = [name for name in globals() if name.isupper()]
+

--- a/src/ui/theme/shadows.py
+++ b/src/ui/theme/shadows.py
@@ -1,21 +1,22 @@
 import flet as ft
+from . import colors
 
 SHADOW_XL = ft.BoxShadow(
     blur_radius=25,
     offset=ft.Offset(0, 20),
-    color=ft.colors.BLACK12,
+    color=colors.BLACK12,
 )
 
 SHADOW_LG = ft.BoxShadow(
     blur_radius=15,
     offset=ft.Offset(0, 10),
-    color=ft.colors.BLACK12,
+    color=colors.BLACK12,
 )
 
 SHADOW_MD = ft.BoxShadow(
     blur_radius=6,
     offset=ft.Offset(0, 4),
-    color=ft.colors.BLACK12,
+    color=colors.BLACK12,
 )
 
 __all__ = [

--- a/src/utils/chart_utils.py
+++ b/src/utils/chart_utils.py
@@ -11,6 +11,7 @@ from ui.theme.spacing import (
     SPACE_5,
     SPACE_6,
 )
+from ui.theme import colors
 
 class ChartUtils:
     """Utilitários para criação de gráficos e visualizações"""
@@ -29,10 +30,10 @@ class ChartUtils:
             )
         
         # Cores para cada status
-        colors = {
-            "vigente": ft.colors.GREEN,
-            "a_vencer": ft.colors.ORANGE,
-            "vencida": ft.colors.RED
+        status_colors = {
+            "vigente": colors.GREEN,
+            "a_vencer": colors.ORANGE,
+            "vencida": colors.RED,
         }
         
         # Cria seções do gráfico
@@ -44,11 +45,11 @@ class ChartUtils:
                     ft.PieChartSection(
                         value=count,
                         title=f"{percentage:.1f}%",
-                        color=colors[status],
+                        color=status_colors[status],
                         radius=60,
                         title_style=ft.TextStyle(
                             size=12,
-                            color=ft.colors.WHITE,
+                            color=colors.WHITE,
                             weight=ft.FontWeight.BOLD
                         )
                     )
@@ -72,9 +73,9 @@ class ChartUtils:
         
         # Ícones e cores para cada status
         status_info = {
-            "vigente": {"icon": "✅", "color": ft.colors.GREEN, "label": "Vigentes"},
-            "a_vencer": {"icon": "⚠️", "color": ft.colors.ORANGE, "label": "A Vencer"},
-            "vencida": {"icon": "❌", "color": ft.colors.RED, "label": "Vencidas"}
+            "vigente": {"icon": "✅", "color": colors.GREEN, "label": "Vigentes"},
+            "a_vencer": {"icon": "⚠️", "color": colors.ORANGE, "label": "A Vencer"},
+            "vencida": {"icon": "❌", "color": colors.RED, "label": "Vencidas"},
         }
         
         legend_items = []
@@ -126,11 +127,11 @@ class ChartUtils:
             
             # Cor da barra baseada no status predominante
             if data["vencida"] > 0:
-                bar_color = ft.colors.RED_200
+                bar_color = colors.RED_200
             elif data["a_vencer"] > 0:
-                bar_color = ft.colors.ORANGE_200
+                bar_color = colors.ORANGE_200
             else:
-                bar_color = ft.colors.GREEN_200
+                bar_color = colors.GREEN_200
             
             bar = ft.Container(
                 content=ft.Column([
@@ -153,7 +154,7 @@ class ChartUtils:
                 ft.Row(bars, alignment=ft.MainAxisAlignment.SPACE_AROUND)
             ], spacing=SPACE_4),
             padding=ft.padding.all(SPACE_4),
-            border=ft.border.all(1, ft.colors.OUTLINE),
+            border=ft.border.all(1, colors.OUTLINE),
             border_radius=8
         )
     
@@ -176,10 +177,10 @@ class ChartUtils:
         
         # Cria barras horizontais
         bars = []
-        colors = {
-            "vigente": ft.colors.GREEN,
-            "a_vencer": ft.colors.ORANGE,
-            "vencida": ft.colors.RED
+        status_colors = {
+            "vigente": colors.GREEN,
+            "a_vencer": colors.ORANGE,
+            "vencida": colors.RED,
         }
         
         labels = {
@@ -202,7 +203,7 @@ class ChartUtils:
                         ft.Container(
                             width=bar_width,
                             height=20,
-                            bgcolor=colors[status],
+                            bgcolor=status_colors[status],
                             border_radius=2
                         ),
                         ft.Text(f"{percentage:.1f}% ({value_formatted})", size=12)
@@ -214,12 +215,15 @@ class ChartUtils:
         return ft.Container(
             content=ft.Column([
                 ft.Text("Valores por Status", size=14, weight=ft.FontWeight.BOLD),
-                ft.Text(f"Total: R$ {total_value:,.2f}".replace(",", "X").replace(".", ",").replace("X", "."), 
-                       size=12, color=ft.colors.SECONDARY),
+                ft.Text(
+                    f"Total: R$ {total_value:,.2f}".replace(",", "X").replace(".", ",").replace("X", "."),
+                    size=12,
+                    color=colors.TEXT_SECONDARY,
+                ),
                 ft.Column(bars, spacing=0)
             ], spacing=SPACE_4),
             padding=ft.padding.all(SPACE_4),
-            border=ft.border.all(1, ft.colors.OUTLINE),
+            border=ft.border.all(1, colors.OUTLINE),
             border_radius=8
         )
     
@@ -229,13 +233,16 @@ class ChartUtils:
         if not atas_vencimento:
             return ft.Container(
                 content=ft.Row([
-                    ft.Icon(ft.icons.CHECK_CIRCLE, color=ft.colors.GREEN, size=24),
-                    ft.Text("Nenhuma ata próxima do vencimento", color=ft.colors.GREEN)
+                    ft.Icon(ft.icons.CHECK_CIRCLE, color=colors.GREEN, size=24),
+                    ft.Text(
+                        "Nenhuma ata próxima do vencimento",
+                        color=colors.GREEN,
+                    ),
                 ], spacing=SPACE_2),
                 padding=ft.padding.all(SPACE_4),
-                border=ft.border.all(1, ft.colors.GREEN),
+                border=ft.border.all(1, colors.GREEN),
                 border_radius=8,
-                bgcolor=ft.colors.GREEN_50
+                bgcolor=colors.GREEN_50,
             )
         
         # Classifica por urgência
@@ -245,18 +252,18 @@ class ChartUtils:
         
         # Determina cor e ícone baseado na urgência
         if urgente > 0:
-            color = ft.colors.RED
-            bgcolor = ft.colors.RED_50
+            color = colors.RED
+            bgcolor = colors.RED_50
             icon = ft.icons.ERROR
             message = f"🚨 {urgente} ata(s) vencendo em 7 dias ou menos!"
         elif atencao > 0:
-            color = ft.colors.ORANGE
-            bgcolor = ft.colors.ORANGE_50
+            color = colors.ORANGE
+            bgcolor = colors.ORANGE_50
             icon = ft.icons.WARNING
             message = f"⚠️ {atencao} ata(s) vencendo em 30 dias ou menos!"
         else:
-            color = ft.colors.BLUE
-            bgcolor = ft.colors.BLUE_50
+            color = colors.BLUE
+            bgcolor = colors.BLUE_50
             icon = ft.icons.INFO
             message = f"ℹ️ {alerta} ata(s) vencendo em 90 dias ou menos"
         
@@ -288,7 +295,7 @@ class ChartUtils:
                     ft.Text(
                         "Total de Atas",
                         size=12,
-                        color=ft.colors.SECONDARY,
+                        color=colors.TEXT_SECONDARY,
                         max_lines=1,
                         overflow=ft.TextOverflow.ELLIPSIS,
                     ),
@@ -296,7 +303,7 @@ class ChartUtils:
                     ft.Text(
                         "cadastradas",
                         size=10,
-                        color=ft.colors.SECONDARY,
+                        color=colors.TEXT_SECONDARY,
                         max_lines=1,
                         overflow=ft.TextOverflow.ELLIPSIS,
                     ),
@@ -305,9 +312,9 @@ class ChartUtils:
                 spacing=SPACE_1,
             ),
             padding=ft.padding.all(SPACE_4),
-            border=ft.border.all(1, ft.colors.OUTLINE),
+            border=ft.border.all(1, colors.OUTLINE),
             border_radius=8,
-            bgcolor=ft.colors.SURFACE_VARIANT,
+            bgcolor=colors.SURFACE_VARIANT,
             width=160,
         )
         cards.append(card_total)
@@ -320,7 +327,7 @@ class ChartUtils:
                     ft.Text(
                         "Valor Total",
                         size=12,
-                        color=ft.colors.SECONDARY,
+                        color=colors.TEXT_SECONDARY,
                         max_lines=1,
                         overflow=ft.TextOverflow.ELLIPSIS,
                     ),
@@ -328,7 +335,7 @@ class ChartUtils:
                     ft.Text(
                         "em atas",
                         size=10,
-                        color=ft.colors.SECONDARY,
+                        color=colors.TEXT_SECONDARY,
                         max_lines=1,
                         overflow=ft.TextOverflow.ELLIPSIS,
                     ),
@@ -337,9 +344,9 @@ class ChartUtils:
                 spacing=SPACE_1,
             ),
             padding=ft.padding.all(SPACE_4),
-            border=ft.border.all(1, ft.colors.OUTLINE),
+            border=ft.border.all(1, colors.OUTLINE),
             border_radius=8,
-            bgcolor=ft.colors.SURFACE_VARIANT,
+            bgcolor=colors.SURFACE_VARIANT,
             width=160,
         )
         cards.append(card_value)
@@ -352,7 +359,7 @@ class ChartUtils:
                     ft.Text(
                         "Vigentes",
                         size=12,
-                        color=ft.colors.SECONDARY,
+                        color=colors.TEXT_SECONDARY,
                         max_lines=1,
                         overflow=ft.TextOverflow.ELLIPSIS,
                     ),
@@ -360,12 +367,12 @@ class ChartUtils:
                         str(stats["vigente"]),
                         size=24,
                         weight=ft.FontWeight.BOLD,
-                        color=ft.colors.GREEN,
+                        color=colors.GREEN,
                     ),
                     ft.Text(
                         f"{vigentes_pct:.1f}%",
                         size=10,
-                        color=ft.colors.SECONDARY,
+                        color=colors.TEXT_SECONDARY,
                         max_lines=1,
                         overflow=ft.TextOverflow.ELLIPSIS,
                     ),
@@ -374,9 +381,9 @@ class ChartUtils:
                 spacing=SPACE_1,
             ),
             padding=ft.padding.all(SPACE_4),
-            border=ft.border.all(1, ft.colors.GREEN),
+            border=ft.border.all(1, colors.GREEN),
             border_radius=8,
-            bgcolor=ft.colors.GREEN_50,
+            bgcolor=colors.GREEN_50,
             width=160,
         )
         cards.append(card_vigentes)
@@ -389,7 +396,7 @@ class ChartUtils:
                     ft.Text(
                         "A Vencer",
                         size=12,
-                        color=ft.colors.SECONDARY,
+                        color=colors.TEXT_SECONDARY,
                         max_lines=1,
                         overflow=ft.TextOverflow.ELLIPSIS,
                     ),
@@ -397,12 +404,12 @@ class ChartUtils:
                         str(stats["a_vencer"]),
                         size=24,
                         weight=ft.FontWeight.BOLD,
-                        color=ft.colors.ORANGE,
+                        color=colors.ORANGE,
                     ),
                     ft.Text(
                         f"{vencer_pct:.1f}%",
                         size=10,
-                        color=ft.colors.SECONDARY,
+                        color=colors.TEXT_SECONDARY,
                         max_lines=1,
                         overflow=ft.TextOverflow.ELLIPSIS,
                     ),
@@ -411,9 +418,9 @@ class ChartUtils:
                 spacing=SPACE_1,
             ),
             padding=ft.padding.all(SPACE_4),
-            border=ft.border.all(1, ft.colors.ORANGE),
+            border=ft.border.all(1, colors.ORANGE),
             border_radius=8,
-            bgcolor=ft.colors.ORANGE_50,
+            bgcolor=colors.ORANGE_50,
             width=160,
         )
         cards.append(card_vencer)


### PR DESCRIPTION
## Summary
- centralize palette and semantic aliases in `colors.py`
- drop theme toggling and use color tokens across UI components
- replace inline color literals in scripts and utilities

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892e527f6f48322ac32912044a29f91