### PR TITLE
Guard filter label update until after control added to page

### DIFF
--- a/src/main_gui.py
+++ b/src/main_gui.py
@@ -254,7 +254,8 @@ class AtaApp:
         else:
             label = f"{len(self.filtros_status)} Filtros Ativos"
         self.filter_label.value = label
-        self.filter_label.update()
+        if self.filter_label.page:
+            self.filter_label.update()
 
     def apply_filters(self):
         """Aplica busca e filtros e atualiza a tabela"""


### PR DESCRIPTION
## Summary
- avoid calling `update()` on filter label before it's added to the page

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ea47423a8832281cf6d4e078215f7