### PR TITLE
Fix AnimatedContainer usage for Flet compatibility

### DIFF
--- a/src/ui/sidebar.py
+++ b/src/ui/sidebar.py
@@ -23,7 +23,7 @@ class SidebarItem(ft.TextButton):
         self.activate_cb = activate_cb
         self.icon = ft.Icon(destination.icon)
         self.label = ft.Text(destination.label)
-        self.label_container = ft.AnimatedContainer(
+        self.label_container = ft.Container(
             content=self.label,
             opacity=1,
             animate=ft.animation.Animation(duration, curve),
@@ -62,7 +62,7 @@ class SidebarItem(ft.TextButton):
         )
 
 
-class Sidebar(ft.AnimatedContainer):
+class Sidebar(ft.Container):
     def __init__(self, app, open_width: int = 240, closed_width: int = 64, duration: int = 300, curve: str = "ease"):
         self.app = app
         self.open_width = open_width


### PR DESCRIPTION
## Summary
- replace `ft.AnimatedContainer` with `ft.Container` in `Sidebar` and `SidebarItem` to match current Flet API

## Testing
- `make test` *(fails: .venv/bin/python3: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689ea7651acc8322ba38d915c4b2b155