### PR TITLE
fix sidebar update before page assignment

### DIFF
--- a/src/ui/sidebar.py
+++ b/src/ui/sidebar.py
@@ -138,7 +138,8 @@ class Sidebar(ft.Container):
             item.set_collapsed(not value)
         self.app.page.client_storage.set("sidebar_open", json.dumps(value))
         print("sidebar_opened" if value else "sidebar_closed")
-        self.update()
+        if self.page:
+            self.update()
 
     def restore_state(self):
         stored = self.app.page.client_storage.get("sidebar_open")


### PR DESCRIPTION
## Summary
- avoid updating sidebar before it's added to the page

## Testing
- `python test_imports.py`


------
https://chatgpt.com/codex/tasks/task_e_689ea82855e08322a6a5721a56091484