### PR TITLE
Refatora sidebar com menu estilo ChatGPT

### DIFF
--- a/src/main_gui.py
+++ b/src/main_gui.py
@@ -62,6 +62,7 @@ class AtaApp:
     
     def build_ui(self):
         """Constrói a interface do usuário usando navegação lateral"""
+        self.sidebar = Sidebar(self)
         self.page.appbar = build_header(
             nova_ata_cb=self.nova_ata_click,
             verificar_alertas_cb=self.verificar_alertas_manual,
@@ -69,9 +70,8 @@ class AtaApp:
             relatorio_mensal_cb=lambda e: self.gerar_relatorio_manual("mensal"),
             testar_email_cb=self.testar_email,
             status_cb=self.mostrar_status_sistema,
+            toggle_sidebar_cb=self.sidebar.toggle_sidebar,
         )
-
-        self.sidebar = Sidebar(self)
         self.body_container = ft.Container(
             padding=ft.padding.only(top=SPACE_4, bottom=SPACE_4),
             expand=True,

--- a/src/ui/main_view.py
+++ b/src/ui/main_view.py
@@ -62,6 +62,7 @@ def build_header(
     relatorio_mensal_cb: Callable,
     testar_email_cb: Callable,
     status_cb: Callable,
+    toggle_sidebar_cb: Callable,
 ) -> ft.AppBar:
     """Return AppBar with menu actions and new ata button."""
     actions_row = ft.Row(
@@ -87,9 +88,19 @@ def build_header(
         vertical_alignment=ft.CrossAxisAlignment.CENTER,
     )
 
+    menu_button = ft.IconButton(
+        icon=ft.icons.SIDE_NAVIGATION,
+        tooltip="Menu",
+        on_click=toggle_sidebar_cb,
+    )
+
     return ft.AppBar(
-        leading=ft.Icon(ft.icons.DESCRIPTION_OUTLINED),
-        leading_width=40,
+        leading=ft.Container(
+            content=menu_button,
+            padding=ft.padding.symmetric(horizontal=12),
+            alignment=ft.alignment.center,
+        ),
+        leading_width=56,
         title=text(
             "Ata de Registro de Preços",
             size=TEXT_XL,

--- a/src/ui/sidebar.py
+++ b/src/ui/sidebar.py
@@ -1,5 +1,4 @@
 import json
-import math
 import flet as ft
 
 from .theme.spacing import SPACE_2, SPACE_3, SPACE_5
@@ -63,7 +62,7 @@ class SidebarItem(ft.TextButton):
 
 
 class Sidebar(ft.Container):
-    def __init__(self, app, open_width: int = 240, closed_width: int = 64, duration: int = 300, curve: str = "ease"):
+    def __init__(self, app, open_width: int = 260, closed_width: int = 0, duration: int = 300, curve: str = "ease"):
         self.app = app
         self.open_width = open_width
         self.closed_width = closed_width
@@ -79,16 +78,8 @@ class Sidebar(ft.Container):
         controls = []
         for d in self.destinations:
             controls.append(self.render_sidebar_item(d.icon, d.label, d.name, d.index == self.app.current_tab))
-        self.toggle_btn = ft.IconButton(
-            icon=ft.icons.CHEVRON_RIGHT,
-            tooltip="Colapsar menu",
-            on_click=self.toggle_sidebar,
-            rotate=ft.transform.Rotate(0),
-            animate_rotation=ft.animation.Animation(duration, curve),
-        )
-        self.toggle_btn.aria_label = "Colapsar menu"
         content = ft.Column(
-            [ft.Row([self.toggle_btn], alignment=ft.MainAxisAlignment.END), *controls],
+            controls,
             spacing=SPACE_3,
             expand=True,
         )
@@ -130,14 +121,9 @@ class Sidebar(ft.Container):
     def set_sidebar_open(self, value: bool):
         self.sidebar_open = value
         self.width = self.open_width if value else self.closed_width
-        self.toggle_btn.rotate.angle = 0 if value else math.pi
-        label = "Colapsar menu" if value else "Expandir menu"
-        self.toggle_btn.tooltip = label
-        self.toggle_btn.aria_label = label
         for item in self.items:
-            item.set_collapsed(not value)
+            item.visible = value
         self.app.page.client_storage.set("sidebar_open", json.dumps(value))
-        print("sidebar_opened" if value else "sidebar_closed")
         if self.page:
             self.update()
 


### PR DESCRIPTION
## Summary
- Substitui ícone inicial por side_navigation com padding e alinhamento central
- Controla abertura da sidebar pelo app bar e remove botão interno
- Ajusta sidebar para largura zero ao fechar, semelhante ao ChatGPT

## Testing
- ⚠️ `make test` (faltou ambiente virtual)
- ✅ `python3 test_imports.py`


------
https://chatgpt.com/codex/tasks/task_e_689eace4ad308322b9830486312a06c0