### PR TITLE
fix: replace deprecated navigation icon

### DIFF
--- a/src/ui/main_view.py
+++ b/src/ui/main_view.py
@@ -89,7 +89,7 @@ def build_header(
     )
 
     menu_button = ft.IconButton(
-        icon=ft.icons.SIDE_NAVIGATION,
+        icon=ft.icons.MENU,
         tooltip="Menu",
         on_click=toggle_sidebar_cb,
     )


### PR DESCRIPTION
## Summary
- use `ft.icons.MENU` for sidebar toggle

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689eae7149b0832288ed16609dba90ca