### PR TITLE
feat: use side navigation icon for sidebar menu

### DIFF
--- a/src/ui/sidebar.py
+++ b/src/ui/sidebar.py
@@ -80,7 +80,7 @@ class Sidebar(ft.Container):
         for d in self.destinations:
             controls.append(self.render_sidebar_item(d.icon, d.label, d.name, d.index == self.app.current_tab))
         self.toggle_btn = ft.IconButton(
-            icon=ft.icons.CHEVRON_RIGHT,
+            icon="side_navigation",
             tooltip="Colapsar menu",
             on_click=self.toggle_sidebar,
             rotate=ft.transform.Rotate(0),


### PR DESCRIPTION
## Summary
- use side navigation Material icon for sidebar menu toggle

## Testing
- `python test_imports.py`

------
https://chatgpt.com/codex/tasks/task_e_689eb18fcb10832281e011f2fb2673f7