### PR TITLE
style: center appbar menu button

### DIFF
--- a/src/ui/main_view.py
+++ b/src/ui/main_view.py
@@ -64,19 +64,37 @@ def build_header(
     status_cb: Callable,
 ) -> ft.AppBar:
     """Return AppBar with menu actions and new ata button."""
+    appbar_height = 56
+
+    menu_button = ft.PopupMenuButton(
+        tooltip="Ferramentas",
+        content=ft.Container(
+            content=ft.Row(
+                [
+                    ft.IconButton(
+                        icon=ft.icons.SETTINGS,
+                        icon_size=24,
+                        tooltip="Ferramentas",
+                    )
+                ],
+                alignment=ft.MainAxisAlignment.CENTER,
+                vertical_alignment=ft.CrossAxisAlignment.CENTER,
+            ),
+            height=appbar_height,
+            padding=ft.padding.symmetric(horizontal=SPACE_5),
+        ),
+        items=[
+            ft.PopupMenuItem(text="🔍 Verificar Alertas", on_click=verificar_alertas_cb),
+            ft.PopupMenuItem(text="📊 Relatório Semanal", on_click=relatorio_semanal_cb),
+            ft.PopupMenuItem(text="📈 Relatório Mensal", on_click=relatorio_mensal_cb),
+            ft.PopupMenuItem(text="📧 Testar Email", on_click=testar_email_cb),
+            ft.PopupMenuItem(text="ℹ️ Status Sistema", on_click=status_cb),
+        ],
+    )
+
     actions_row = ft.Row(
         [
-            ft.PopupMenuButton(
-                icon=ft.icons.SETTINGS,
-                tooltip="Ferramentas",
-                items=[
-                    ft.PopupMenuItem(text="🔍 Verificar Alertas", on_click=verificar_alertas_cb),
-                    ft.PopupMenuItem(text="📊 Relatório Semanal", on_click=relatorio_semanal_cb),
-                    ft.PopupMenuItem(text="📈 Relatório Mensal", on_click=relatorio_mensal_cb),
-                    ft.PopupMenuItem(text="📧 Testar Email", on_click=testar_email_cb),
-                    ft.PopupMenuItem(text="ℹ️ Status Sistema", on_click=status_cb),
-                ],
-            ),
+            menu_button,
             primary_button(
                 "Nova Ata",
                 icon=ft.icons.ADD,
@@ -105,6 +123,7 @@ def build_header(
                 padding=ft.padding.only(right=SPACE_5),
             )
         ],
+        height=appbar_height,
     )
 
 


### PR DESCRIPTION
## Summary
- center AppBar menu icon using flex row
- ensure menu trigger has consistent padding and icon size

## Testing
- `make test` *(fails: .venv/bin/python3 not found)*
- `make install` *(fails: .venv/bin/pip: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689eb3e5ae9483229b21d1fc72268884