### PR TITLE
fix: update AppBar height parameter

### DIFF
--- a/src/ui/main_view.py
+++ b/src/ui/main_view.py
@@ -80,7 +80,7 @@ def build_header(
                 alignment=ft.MainAxisAlignment.CENTER,
                 vertical_alignment=ft.CrossAxisAlignment.CENTER,
             ),
-            height=appbar_height,
+            toolbar_toolbar_height=appbar_height,
             padding=ft.padding.symmetric(horizontal=SPACE_5),
         ),
         items=[
@@ -123,7 +123,7 @@ def build_header(
                 padding=ft.padding.only(right=SPACE_5),
             )
         ],
-        height=appbar_height,
+        toolbar_height=appbar_height,
     )
 
 


### PR DESCRIPTION
## Summary
- replace deprecated `height` argument with `toolbar_height` when building `AppBar`

## Testing
- `python test_imports.py`


------
https://chatgpt.com/codex/tasks/task_e_689eb54e43148322b1d05549c2890a42