### PR TITLE
Fix header menu container height parameter

### DIFF
--- a/src/ui/main_view.py
+++ b/src/ui/main_view.py
@@ -80,7 +80,9 @@ def build_header(
                 alignment=ft.MainAxisAlignment.CENTER,
                 vertical_alignment=ft.CrossAxisAlignment.CENTER,
             ),
-            toolbar_toolbar_height=appbar_height,
+            # ``PopupMenuButton`` doesn't support ``toolbar_height`` like ``AppBar``,
+            # so we explicitly set the container height to match the AppBar.
+            height=appbar_height,
             padding=ft.padding.symmetric(horizontal=SPACE_5),
         ),
         items=[


### PR DESCRIPTION
## Summary
- avoid TypeError when building header by using valid `height` argument for Container

## Testing
- `python test_imports.py`


------
https://chatgpt.com/codex/tasks/task_e_689eb63a0c5083229f069d91ebc4f066