### PR TITLE
Refatora sidebar com tokens de espaçamento e colapso aprimorado

### DIFF
--- a/src/main_gui.py
+++ b/src/main_gui.py
@@ -80,7 +80,7 @@ class AtaApp:
         layout = ft.Row([
             self.sidebar,
             self.body_container,
-        ], expand=True)
+        ], spacing=SPACE_5, expand=True)
 
         self.page.add(layout)
         self.update_responsive_layout(self.page.width)
@@ -89,6 +89,15 @@ class AtaApp:
     def update_responsive_layout(self, width: int):
         """Atualiza layout responsivo da barra lateral."""
         self.sidebar.update_layout(width)
+        self.page.update()
+
+    def toggle_theme(self, e):
+        """Alterna entre temas claro e escuro."""
+        self.page.theme_mode = (
+            ft.ThemeMode.DARK
+            if self.page.theme_mode == ft.ThemeMode.LIGHT
+            else ft.ThemeMode.LIGHT
+        )
         self.page.update()
     
     def build_stats_panel(self):
@@ -142,13 +151,18 @@ class AtaApp:
         )
         return ft.Column([self.atas_vencimento_container], spacing=0, expand=True)
 
+    def build_config_view(self):
+        return ft.Column([ft.Text("Configurações")], spacing=0, expand=True)
+
     def update_body(self):
         if self.current_tab == 0:
             content = self.build_dashboard_view()
         elif self.current_tab == 1:
             content = self.build_atas_view()
-        else:
+        elif self.current_tab == 2:
             content = self.build_vencimentos_view()
+        else:
+            content = self.build_config_view()
         self.body_container.content = content
         self.page.update()
 

--- a/src/ui/sidebar.py
+++ b/src/ui/sidebar.py
@@ -2,7 +2,7 @@ import json
 import math
 import flet as ft
 
-from .theme.spacing import SPACE_2, SPACE_3, SPACE_5
+from .theme.spacing import SPACE_2, SPACE_3, SPACE_4, SPACE_5, SPACE_6
 from .theme.shadows import SHADOW_XL
 from .theme import colors
 
@@ -21,6 +21,7 @@ class SidebarItem(ft.TextButton):
         super().__init__()
         self.destination = destination
         self.activate_cb = activate_cb
+        self.tab_index = 0
         self.icon = ft.Icon(destination.icon)
         self.label = ft.Text(destination.label)
         self.label_container = ft.Container(
@@ -34,10 +35,15 @@ class SidebarItem(ft.TextButton):
             alignment=ft.MainAxisAlignment.START,
             vertical_alignment=ft.CrossAxisAlignment.CENTER,
         )
+        self.expand = True
         self.style = ft.ButtonStyle(
             padding=ft.padding.all(SPACE_3),
             shape=ft.RoundedRectangleBorder(radius=8),
-            bgcolor={ft.MaterialState.HOVERED: ft.colors.with_opacity(0.05, ft.colors.BLACK)},
+            bgcolor={
+                ft.MaterialState.HOVERED: ft.colors.with_opacity(0.05, ft.colors.BLACK),
+                ft.MaterialState.FOCUSED: ft.colors.with_opacity(0.08, ft.colors.BLACK),
+            },
+            overlay_color={ft.MaterialState.FOCUSED: ft.colors.with_opacity(0.08, ft.colors.BLACK)},
         )
         self.on_click = self.on_pressed
 
@@ -58,27 +64,33 @@ class SidebarItem(ft.TextButton):
             bgcolor={
                 ft.MaterialState.DEFAULT: ft.colors.SECONDARY_CONTAINER if active else None,
                 ft.MaterialState.HOVERED: ft.colors.with_opacity(0.05, ft.colors.BLACK),
+                ft.MaterialState.FOCUSED: ft.colors.with_opacity(0.08, ft.colors.BLACK),
             },
+            overlay_color={ft.MaterialState.FOCUSED: ft.colors.with_opacity(0.08, ft.colors.BLACK)},
         )
 
 
 class Sidebar(ft.Container):
-    def __init__(self, app, open_width: int = 240, closed_width: int = 64, duration: int = 300, curve: str = "ease"):
+    def __init__(self, app, open_width: int = 240, closed_width: int = 68, duration: int = 300, curve: str = "ease"):
         self.app = app
         self.open_width = open_width
         self.closed_width = closed_width
         self.duration = duration
         self.curve = curve
-        self.sidebar_open = True
+        self.collapsed = False
+
         self.destinations = [
             NavigationDestination("dashboard", "Dashboard", ft.icons.INSIGHTS_OUTLINED, ft.icons.INSIGHTS, 0),
             NavigationDestination("atas", "Atas", ft.icons.LIST_OUTLINED, ft.icons.LIST, 1),
             NavigationDestination("vencimentos", "Vencimentos", ft.icons.ALARM_OUTLINED, ft.icons.ALARM, 2),
+            NavigationDestination("config", "Configurações", ft.icons.SETTINGS_OUTLINED, ft.icons.SETTINGS, 3),
         ]
+
         self.items: list[SidebarItem] = []
-        controls = []
+        nav_items: list[ft.Control] = []
         for d in self.destinations:
-            controls.append(self.render_sidebar_item(d.icon, d.label, d.name, d.index == self.app.current_tab))
+            nav_items.append(self.render_sidebar_item(d.icon, d.label, d.name, d.index == self.app.current_tab))
+
         self.toggle_btn = ft.IconButton(
             icon=ft.icons.MENU_OUTLINED,
             tooltip="Colapsar menu",
@@ -87,19 +99,61 @@ class Sidebar(ft.Container):
             animate_rotation=ft.animation.Animation(duration, curve),
         )
         self.toggle_btn.aria_label = "Colapsar menu"
-        content = ft.Column(
-            [ft.Row([self.toggle_btn], alignment=ft.MainAxisAlignment.END), *controls],
-            spacing=SPACE_3,
+
+        self.logo = ft.Icon(ft.icons.DESCRIPTION_OUTLINED)
+        self.title = ft.Text("Ata RP")
+        self.title_container = ft.Container(
+            content=self.title,
+            opacity=1,
+            animate=ft.animation.Animation(duration, curve),
+        )
+        left_header = ft.Row(
+            [self.logo, self.title_container],
+            spacing=SPACE_2,
+            alignment=ft.MainAxisAlignment.START,
+            vertical_alignment=ft.CrossAxisAlignment.CENTER,
+        )
+        header_row = ft.Row(
+            [left_header, self.toggle_btn],
+            alignment=ft.MainAxisAlignment.SPACE_BETWEEN,
+            vertical_alignment=ft.CrossAxisAlignment.CENTER,
+        )
+        self.header = ft.Container(
+            content=header_row,
+            padding=ft.padding.symmetric(horizontal=SPACE_5, vertical=SPACE_4),
+        )
+
+        self.nav = ft.Container(
+            content=ft.Column(nav_items, spacing=SPACE_3, expand=True),
+            padding=ft.padding.symmetric(horizontal=SPACE_5, vertical=SPACE_3),
             expand=True,
         )
+
+        theme_btn = ft.IconButton(
+            icon=ft.icons.BRIGHTNESS_6_OUTLINED,
+            tooltip="Alternar tema",
+            on_click=self.app.toggle_theme if hasattr(self.app, "toggle_theme") else None,
+        )
+        self.footer = ft.Container(
+            content=ft.Row([theme_btn], alignment=ft.MainAxisAlignment.CENTER, vertical_alignment=ft.CrossAxisAlignment.CENTER),
+            padding=ft.padding.symmetric(vertical=SPACE_3, horizontal=SPACE_5),
+            margin=ft.margin.only(top=SPACE_6),
+        )
+
+        content = ft.Column([
+            self.header,
+            self.nav,
+            self.footer,
+        ], spacing=0, expand=True)
+
         super().__init__(
             content=content,
             width=open_width,
             bgcolor=colors.WHITE,
-            padding=ft.padding.all(SPACE_5),
             shadow=SHADOW_XL,
             animate=ft.animation.Animation(duration, curve),
         )
+
         self.update_selected_item()
         self.restore_state()
 
@@ -125,30 +179,32 @@ class Sidebar(ft.Container):
             item.set_active(item.destination.index == getattr(self, "selected_index", self.app.current_tab))
 
     def toggle_sidebar(self, e=None):
-        self.set_sidebar_open(not self.sidebar_open)
+        self.set_collapsed(not self.collapsed)
 
-    def set_sidebar_open(self, value: bool):
-        self.sidebar_open = value
-        self.width = self.open_width if value else self.closed_width
-        self.toggle_btn.rotate.angle = 0 if value else math.pi
-        label = "Colapsar menu" if value else "Expandir menu"
+    def set_collapsed(self, value: bool):
+        self.collapsed = value
+        self.width = self.closed_width if value else self.open_width
+        self.toggle_btn.rotate.angle = math.pi if value else 0
+        label = "Expandir menu" if value else "Colapsar menu"
         self.toggle_btn.tooltip = label
         self.toggle_btn.aria_label = label
+        self.title_container.width = 0 if value else None
+        self.title_container.opacity = 0 if value else 1
         for item in self.items:
-            item.set_collapsed(not value)
-        self.app.page.client_storage.set("sidebar_open", json.dumps(value))
-        print("sidebar_opened" if value else "sidebar_closed")
+            item.set_collapsed(value)
+        self.app.page.client_storage.set("sidebar_collapsed", json.dumps(value))
+        print("sidebar_collapsed" if value else "sidebar_expanded")
         if self.page:
             self.update()
 
     def restore_state(self):
-        stored = self.app.page.client_storage.get("sidebar_open")
+        stored = self.app.page.client_storage.get("sidebar_collapsed")
         if stored is not None:
             value = json.loads(stored)
         else:
-            value = self.app.page.width >= 768
-        self.set_sidebar_open(value)
+            value = self.app.page.width < 768
+        self.set_collapsed(value)
 
     def update_layout(self, width: int):
-        if width < 768 and self.sidebar_open:
-            self.set_sidebar_open(False)
+        if width < 768 and not self.collapsed:
+            self.set_collapsed(True)


### PR DESCRIPTION
## Summary
- Reestrutura Sidebar com seções de header, navegação e footer usando apenas tokens de espaçamento
- Centraliza ícones e adiciona item de Configurações, tema e persistência `sidebar_collapsed`
- Garante espaçamento lateral consistente entre Sidebar e conteúdo

## Testing
- `python -m py_compile src/ui/sidebar.py src/main_gui.py`
- `python test_imports.py`


------
https://chatgpt.com/codex/tasks/task_e_689eb829e84083229eaf785697a2048f