### PR TITLE
Fix IconButton aria_label init error

### DIFF
--- a/src/ui/sidebar.py
+++ b/src/ui/sidebar.py
@@ -164,10 +164,12 @@ class Sidebar(ft.Container):
             icon=ft.icons.MENU,
             icon_size=24,
             tooltip="Colapsar menu" if not self.collapsed else "Expandir menu",
-            aria_label="Colapsar menu" if not self.collapsed else "Expandir menu",
             on_click=self.toggle_sidebar,
             rotate=ft.transform.Rotate(0 if not self.collapsed else math.pi),
             animate_rotation=ft.animation.Animation(duration, curve),
+        )
+        self.toggle_btn.aria_label = (
+            "Colapsar menu" if not self.collapsed else "Expandir menu"
         )
 
         content = ft.Column(


### PR DESCRIPTION
## Summary
- avoid Flet TypeError by removing unsupported `aria_label` argument from `IconButton` constructor
- set `aria_label` attribute after creating the toggle button to preserve accessibility labels

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ebbcd12c0832283d91d73d3921165