### PR TITLE
Avoid sidebar update before page is attached

### DIFF
--- a/src/ui/sidebar.py
+++ b/src/ui/sidebar.py
@@ -134,7 +134,8 @@ class SidebarItem(ft.Container):
                 ),
             },
         )
-        self.update()
+        if self.page:
+            self.update()
 
 
 class Sidebar(ft.Container):


### PR DESCRIPTION
## Summary
- Prevent SidebarItem from calling update before it is added to a page

## Testing
- `python test_imports.py`

------
https://chatgpt.com/codex/tasks/task_e_68a25606adcc8322bab7051797c58e05